### PR TITLE
[AT-56]: 사업자등록번호, 홈택스 업종 코드, 홈택스 업종의 이름 매핑 테이블 생성

### DIFF
--- a/app/models/registration_number_classification_code.rb
+++ b/app/models/registration_number_classification_code.rb
@@ -1,0 +1,3 @@
+class RegistrationNumberClassificationCode < ActiveRecord::Base
+
+end

--- a/db/migrate/20200427095914_create_reg_num_classification_codes.rb
+++ b/db/migrate/20200427095914_create_reg_num_classification_codes.rb
@@ -1,0 +1,11 @@
+class CreateRegNumClassificationCodes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :registration_number_classification_codes do |t|
+      t.string :registration_number, limit: 10, null: false, comment: "사업자등록번호", index: {unique: true}
+      t.string :classification_code, limit: 6, null: false, comment: "주업종코드"
+      t.string :classification_name, limit: 64, null: false, comment: "주업종명"
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
아래 테이블에 대한 migration을 추가 합니다.

## registration_number_classification_codes

Distinct한 (사업자 등록번호, classification_code, classification_name)의 집합을 아래의 쿼리들로 생성

- businesss테이블
```sql
 SELECT b.registration_number,
           h.classification_code AS hometax_classification_code,
           h.classification_name AS hometax_classification_name,
           'business' AS source
    FROM businesses b 
    JOIN hometax_businesses h
    ON b.id = h.business_id
```
- 홈택스 현금영수증
```sql
SELECT DISTINCT
           vendor_registration_number AS registration_number,
           vendor_business_code AS hometax_classification_code,
           null AS hometax_classification_name,
           'purchases_cash_receipts' AS source
    FROM hometax_purchases_cash
```
- 홈택스 카드 매입
```sql
SELECT DISTINCT
           vendor_registration_number AS registration_number,
           vendor_business_classification_code AS hometax_classification_code,
           vendor_business_category AS hometax_classification_name,
           'card_purchases' AS source           
    FROM hometax_purchases_card
```

위와 같이 3개 source로 부터 만들수 있는 distinct한 사업장 번호들은 200만개 
결국 hometax_purchases_invoices 테이블에 registration_number기준으로 join해서 classification_code를 만들 수 있는 수는 아래 이슈 참고

https://koreacreditdata.atlassian.net/browse/AT-55

## 활용처

- 최종적으로 snowdon의 hometax_purchases_invoices 테이블의 데이터와 위의 registration_number_classification_codes 두 개 테이블을 registration_number기준으로 join해서 classification을 만들수 있게 함. 
- 최종적으로는 신고하는 (사업장의 classification, 거래처 사업장의 classification) pair를 기준으로 계정과목 분류를 계산 하는 로직에서 활용(별도 이슈로 진행 예정)

