### PR TITLE
[AT-60] 홈택스 종소세 안내문 스크래핑

### DIFF
--- a/app/models/hometax_business_expense.rb
+++ b/app/models/hometax_business_expense.rb
@@ -1,0 +1,2 @@
+class HometaxBusinessExpense < ApplicationRecord
+end

--- a/app/models/hometax_individual_income.rb
+++ b/app/models/hometax_individual_income.rb
@@ -1,0 +1,2 @@
+class HometaxIndividualIncome < ApplicationRecord
+end

--- a/db/migrate/20200429114915_create_hometax_individual_incomes.rb
+++ b/db/migrate/20200429114915_create_hometax_individual_incomes.rb
@@ -1,0 +1,39 @@
+class CreateHometaxIndividualIncomes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :hometax_individual_incomes do |t|
+      t.string :name, null: false, comment: "이름"
+      t.string :birthday, null: false, comment: "생년월일"
+      t.string :declare_type, null: false, comment: "신고안내유형"
+      t.string :account_type, null: false, comment: "기장의무구분"
+      t.string :base_expense_rate, null: false, comment: "추계신고시 적용경비율"
+      t.string :delcare_year, null: false, comment: "귀속년도"
+
+      t.boolean :interest_income, null: false, comment: "이자소득"
+      t.boolean :dividend_income, null: false, comment: "배당소득"
+      t.boolean :business_income, null: false, comment: "사업소득"
+      t.boolean :wage_single_income, null: false, comment: "근로소득(단일)"
+      t.boolean :wage_multiple_income, null: false, comment: "근로소득(복수)"
+      t.boolean :pension_income, null: false, comment: "연금소득"
+      t.boolean :other_income, null: false, comment: "기타소득"
+
+      t.integer :prepaid_tax, null: false, comment: "기납부세액"
+      t.integer :national_pension, null: false, comment: "국민연금보험료"
+      t.integer :personal_pension, null: false, comment: "개인연금저축"
+      t.integer :merchant_pension, null: false, comment: "소기업소상공인공제부금"
+      t.integer :retirement_pension_tax_credit, null: false, comment: "퇴직연금세액공제"
+      t.integer :pension_account_tax_credit, null: false, comment: "연금계좌세액공제"
+
+      t.integer :no_declare_penalty, null: false, comment: "무신고 또는 무기장가산세"
+      t.integer :unfaithful_report_invoice_penalty, null: false, comment: "(세금)계산서관련 보고불성실"
+      t.integer :no_cash_receipits_penalty, null: false, comment: "현금영수증미가맹"
+      t.integer :less_decline_cash_receipits_penalty, null: false, comment: "현금영수증발급거부(10만미만)"
+      t.integer :more_decline_cash_receipits_penalty, null: false, comment: "현금영수증발급거부(10만이상)"
+      t.integer :less_decline_card_penalty, null: false, comment: "신용카드발급거부(10만미만)"
+      t.integer :more_decline_card_penalty, null: false, comment: "신용카드발급거부(10만이상)"
+      t.integer :no_business_report_penalty, null: false, comment: "사업장현황신고불성실"
+      t.integer :no_business_account_penalty, null: false, comment: "사업용계좌미신고"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200429114915_create_hometax_individual_incomes.rb
+++ b/db/migrate/20200429114915_create_hometax_individual_incomes.rb
@@ -10,11 +10,12 @@ class CreateHometaxIndividualIncomes < ActiveRecord::Migration[6.0]
 
       t.boolean :interest_income, null: false, comment: "이자소득"
       t.boolean :dividend_income, null: false, comment: "배당소득"
-      t.boolean :business_income, null: false, comment: "사업소득"
       t.boolean :wage_single_income, null: false, comment: "근로소득(단일)"
       t.boolean :wage_multiple_income, null: false, comment: "근로소득(복수)"
       t.boolean :pension_income, null: false, comment: "연금소득"
       t.boolean :other_income, null: false, comment: "기타소득"
+      t.boolean :religions_income, null: false, comment: "종교인기타소득"
+      t.boolean :yearend_settlement_income, null: false, comment: "사업연말정산소득"
 
       t.integer :prepaid_tax, null: false, comment: "기납부세액"
       t.integer :national_pension, null: false, comment: "국민연금보험료"
@@ -23,15 +24,16 @@ class CreateHometaxIndividualIncomes < ActiveRecord::Migration[6.0]
       t.integer :retirement_pension_tax_credit, null: false, comment: "퇴직연금세액공제"
       t.integer :pension_account_tax_credit, null: false, comment: "연금계좌세액공제"
 
-      t.integer :no_declare_penalty, null: false, comment: "무신고 또는 무기장가산세"
+      t.string :declare_penalty_case, null: false, comment: "무신고 또는 무기장가산세"
       t.integer :unfaithful_report_invoice_penalty, null: false, comment: "(세금)계산서관련 보고불성실"
-      t.integer :no_cash_receipits_penalty, null: false, comment: "현금영수증미가맹"
-      t.integer :less_decline_cash_receipits_penalty, null: false, comment: "현금영수증발급거부(10만미만)"
-      t.integer :more_decline_cash_receipits_penalty, null: false, comment: "현금영수증발급거부(10만이상)"
-      t.integer :less_decline_card_penalty, null: false, comment: "신용카드발급거부(10만미만)"
-      t.integer :more_decline_card_penalty, null: false, comment: "신용카드발급거부(10만이상)"
-      t.integer :no_business_report_penalty, null: false, comment: "사업장현황신고불성실"
-      t.integer :no_business_account_penalty, null: false, comment: "사업용계좌미신고"
+      t.string :not_register_cash_receipts, null: false, comment: "현금영수증미가맹"
+      t.integer :not_issued_cash_receipts_amount, null: false, comment: "현금영수증미발급 금액"
+      t.integer :decline_cash_receipts_penalty_count, null: false, comment: "현금영수증발급거부(10만미만)"
+      t.integer :decline_cash_receipts_penalty_amount, null: false, comment: "현금영수증발급거부(10만이상)"
+      t.integer :decline_card_penalty_count, null: false, comment: "신용카드발급거부(10만미만)"
+      t.integer :decline_card_penalty_amount, null: false, comment: "신용카드발급거부(10만이상)"
+      t.integer :unfaithful_business_report_penalty, null: false, comment: "사업장현황신고불성실"
+      t.string :no_business_account_penalty, null: false, comment: "사업용계좌미신고"
 
       t.timestamps
     end

--- a/db/migrate/20200429114915_create_hometax_individual_incomes.rb
+++ b/db/migrate/20200429114915_create_hometax_individual_incomes.rb
@@ -1,6 +1,7 @@
 class CreateHometaxIndividualIncomes < ActiveRecord::Migration[6.0]
   def change
     create_table :hometax_individual_incomes do |t|
+      t.references :user, null: false, foreign_key: true
       t.string :name, null: false, comment: "이름"
       t.string :birthday, null: false, comment: "생년월일"
       t.string :declare_type, null: false, comment: "신고안내유형"
@@ -37,5 +38,6 @@ class CreateHometaxIndividualIncomes < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+    add_index :hometax_individual_incomes, [:user_id, :delcare_year], unique: true
   end
 end

--- a/db/migrate/20200429151243_create_hometax_business_expenses.rb
+++ b/db/migrate/20200429151243_create_hometax_business_expenses.rb
@@ -1,0 +1,20 @@
+class CreateHometaxBusinessExpenses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :hometax_business_expenses do |t|
+      t.string :registration_number, comment: "사업자등록번호"
+      t.string :business_name, null: false, comment: "상호"      
+      t.string :expense_type, null: false, comment: "수입종류구분코드"
+      t.string :classficaition_code, null: false, comment: "업종코드"
+      t.string :business_type, null: false, comment: "사업형태"
+      t.string :account_type, null: false, comment: "기장의무"
+      t.integer :expnese_amount, null: false, comment: "수입금액"
+      t.float :base_expense_rate, null: false, comment: "기준경비율(일반)"
+      t.float :self_base_expense_rate, null: false, comment: "기준경비율(자가)"
+      t.float :simple_expense_rate, null: false, comment: "단순경비율(일반)"
+      t.float :self_simple_expense_rate, null: false, comment: "단순경비율(자가)"
+      t.string :wht_agent, comment: "주요원천징수의무자"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200429151243_create_hometax_business_expenses.rb
+++ b/db/migrate/20200429151243_create_hometax_business_expenses.rb
@@ -1,6 +1,7 @@
 class CreateHometaxBusinessExpenses < ActiveRecord::Migration[6.0]
   def change
     create_table :hometax_business_expenses do |t|
+      t.references :hometax_individual_income, null: false, foreign_key: true
       t.string :registration_number, comment: "사업자등록번호"
       t.string :business_name, null: false, comment: "상호"      
       t.string :expense_type, null: false, comment: "수입종류구분코드"
@@ -16,5 +17,6 @@ class CreateHometaxBusinessExpenses < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+    add_index :hometax_business_expenses, :registration_number
   end
 end


### PR DESCRIPTION
종소세 안내문 스크래핑을 위한 migration을 추가합니다.
[종소세 스크래핑 문서](https://koreacreditdata.atlassian.net/wiki/spaces/tax/pages/1170867743?focusedCommentId=1175486957#comment-1175486957)
- 기본사항 : 귀속년도 / 성명 / 생년월일 / 신고안내유형 /기장의무구분 / 추계신고시 적용경비율 
- 소득내역 : 이자 / 배당 / 사업 / 근로(단일) / 근로(복수) / 연금 / 기타
- 연금공제 / 세액공제 내역
- 가산세내역

