### PR TITLE
User account classification rules

### DIFF
--- a/app/controllers/declare_users_controller.rb
+++ b/app/controllers/declare_users_controller.rb
@@ -15,7 +15,7 @@ class DeclareUsersController < ApplicationController
     if @declare_user.save
       business = Snowdon::Business.find_by(public_id: @declare_user.user.user_providers.cashnote.uid)
       simplified_bookkeepings = business.calculate(@declare_user.id)
-      SimplifiedBookkeeping.import(simplified_bookkeepings)
+      SimplifiedBookkeeping.upsert(rows: simplified_bookkeepings)
       render json: { declare_user: json_object }, status: :created
     else
       render json: { errors: errors_json(@declare_user.errors) }, status: :unprocessable_entity

--- a/app/models/simplified_bookkeeping.rb
+++ b/app/models/simplified_bookkeeping.rb
@@ -12,6 +12,7 @@ class SimplifiedBookkeeping < ApplicationRecord
         rows,
         on_duplicate_key_update: {
             conflict_target: %i(registration_number vendor_registration_number purchase_type),
+            index_predicate: "vendor_registration_number IS NOT NULL",
             columns: %i(account_classification_code classification_id amount purchases_count updated_at),
         },
       )

--- a/app/models/snowdon/business.rb
+++ b/app/models/snowdon/business.rb
@@ -36,6 +36,36 @@ class Snowdon::Business < Snowdon::ApplicationRecord
 
   def add_account_classification_code(classification, results, declare_user_id)
     rules = account_classification_rules(classification, vendor_classification_codes(results))
+    user_rules = UserAccountClassificationRule.where(declare_user_id: declare_user_id).group_by{ |r| "#{r.vendor_registration_number}:#{r.purchase_type}" }
+    results.map do |h|
+      h.attributes.merge({
+        declare_user_id: declare_user_id,
+        business_id: id,
+        registration_number: registration_number
+      })
+      user_rule = user_rules["#{h.vendor_registration_number}:#{h.purchase_type}"]
+      if user_rule.present?
+        h.attributes.merge({
+          classification_id: user_rule.first.classification_id,
+        })
+      else
+        rule = h[:vendor_classification_code].nil? ? nil : rules[h[:vendor_classification_code][0..1]]
+        account_classification_code =
+          if rule.nil?
+            h[:purchase_type] == "CardPurchasesApproval" ? nil : "812033"
+          else
+            rule.account_classification_code
+          end
+        h.attributes.merge({
+          classification_id: rule&.classification_id || 32,
+          account_classification_code: account_classification_code,
+        })
+      end
+    end
+  end
+
+  def add_user_account_classification_code(classification, declare_user_id)
+    rules = account_classification_rules(classification, vendor_classification_codes(results))
 
     results.map do |h|
       rule = h[:vendor_classification_code].nil? ? nil : rules[h[:vendor_classification_code][0..1]]

--- a/app/models/user_account_classification_rule.rb
+++ b/app/models/user_account_classification_rule.rb
@@ -1,0 +1,6 @@
+class UserAccountClassificationRule < ApplicationRecord
+  belongs_to :declare_user
+
+  validates :vendor_registration_number, presence: true
+  validates :purchase_type, presence: true
+end

--- a/db/migrate/20200503173159_create_user_account_classification_rules.rb
+++ b/db/migrate/20200503173159_create_user_account_classification_rules.rb
@@ -1,0 +1,17 @@
+class CreateUserAccountClassificationRules < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_account_classification_rules do |t|
+      t.references :declare_user, null: false, foreign_key: true
+      t.references :classification, null: false, foreign_key: true
+
+      t.string :vendor_registration_number, null: false
+      t.string :purchase_type, null: false
+
+      t.boolean :deductible
+
+      t.timestamps
+    end
+    add_index :user_account_classification_rules, [:declare_user_id, :vendor_registration_number, :purchase_type],
+              name: "index_user_classification_rules_on_user_and_business_and_type", unique: true
+  end
+end


### PR DESCRIPTION
유저가 선택한 사업장의 계정과목을 반영하여 간편장부를 업데이트하는 부분 입니다.

SimplifiedBookkeeping.upsert 활용시에 partial index를 반영하기 위해 index_predicate를 추가하였고, 선택한 계정과목을 저장한 UserAccountClassificationRule의 사업자번호, 결제수단에 해당하는 항목에 대해서는 해당 룰을 반영한 classification_id를 반영하도록 하였습니다.