### PR TITLE
홈택스 연금건강고용산재보험료 데이터

### DIFF
--- a/app/models/hometax_social_insurance.rb
+++ b/app/models/hometax_social_insurance.rb
@@ -1,2 +1,3 @@
 class HometaxSocialInsurance < ApplicationRecord
+  belongs_to :declare_user
 end

--- a/app/models/hometax_social_insurance.rb
+++ b/app/models/hometax_social_insurance.rb
@@ -1,0 +1,2 @@
+class HometaxSocialInsurance < ApplicationRecord
+end

--- a/db/migrate/20200508110735_create_hometax_social_insurances.rb
+++ b/db/migrate/20200508110735_create_hometax_social_insurances.rb
@@ -11,6 +11,7 @@ class CreateHometaxSocialInsurances < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
-    add_index :hometax_social_insurances, [:owner_id, :insurance_type, :year], unique: true
+    add_index :hometax_social_insurances, [:owner_id, :insurance_type, :year],
+    name: "index_hometax_social_insurances_on_owner_type_and_year", unique: true
   end
 end

--- a/db/migrate/20200508110735_create_hometax_social_insurances.rb
+++ b/db/migrate/20200508110735_create_hometax_social_insurances.rb
@@ -1,0 +1,16 @@
+class CreateHometaxSocialInsurances < ActiveRecord::Migration[6.0]
+  def change
+    create_table :hometax_social_insurances do |t|
+      t.references :declare_user, foreign_key: true
+      t.bigint :owner_id, null: false
+      t.string :registration_number
+      t.string :business_name
+      t.string :insurance_type, null: false
+      t.integer :amount, null: false
+      t.integer :year
+
+      t.timestamps
+    end
+    add_index :hometax_social_insurances, [:owner_id, :insurance_type, :year], unique: true
+  end
+end


### PR DESCRIPTION
홈택스의 연금건강고용산재보험료 데이터를 수집하기 위한 model 과 table을 추가합니다.

**연도, 사업자번호, 사업자명, 보험종류, 금액** 을 입력합니다.
우선 캐시노트 owner 기준으로 데이터를 넣고 이후에 declare_user를 매핑합니다.
여기서 스크래핑된 총합 금액은 필요 없는데 제거해서 넣어주실수있나요? @contpassion 
