### PR TITLE
[AT-77]: 계정과목 분류 로직에 복리후생비 후처리 로직 추가

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -4,7 +4,7 @@ class AuthController < ApplicationController
     owner = ValidateOwner.call(token: token)
     return render json: { errors: "not found user" }, status: :not_found if owner.blank?
     user = User.find_by(owner_id: owner.id)
-    return render json: { declare_user: user.declare_user&.as_json(only: DeclareUser::JSON_FIELD),
+    return render json: { declare_user: user.declare_user&.as_json(except: DeclareUser::EXCEPT_JSON_FIELD),
                    jwt: user.jwt.token,
                    status: user.declare_users.blank? ? "empty" : user.declare_user.status
                  }, status: :ok if user

--- a/app/controllers/calculated_taxes_controller.rb
+++ b/app/controllers/calculated_taxes_controller.rb
@@ -44,4 +44,25 @@ class CalculatedTaxesController < ApplicationController
       }
     }, status: :ok
   end
+
+  def tax_credits
+    render json: {
+      total_amount: @declare_user.tax_credit_amount,
+      tax_credits: {
+        children_tax_credit_amount: @declare_user.children_tax_credit_amount,
+        newborn_baby_tax_credit_amount: @declare_user.newborn_baby_tax_credit_amount,
+        pensions_tax_credit_amount: @declare_user.pensions_tax_credit_amount,
+      }
+    }, status: :ok
+  end
+
+  def tax_exemptions
+    render json: {
+      total_amount: @declare_user.tax_exemption_amount,
+      tax_exemptions: {
+        base_tax_exemption: @declare_user.base_tax_exemption,
+        online_declare_exemption: 20000,
+      }
+    }, status: :ok
+  end
 end

--- a/app/controllers/calculated_taxes_controller.rb
+++ b/app/controllers/calculated_taxes_controller.rb
@@ -14,4 +14,34 @@ class CalculatedTaxesController < ApplicationController
       } 
     }, status: :ok
   end
+
+  def deductions
+    render json: {
+      total_amount: @declare_user.deductible_persons.sum(&:deduction_amount) + @declare_user.deduction_amount + @declare_user.pensions_sum,
+      personal_deduction: {
+        total_amount: @declare_user.deductible_persons.sum(&:deduction_amount) + @declare_user.deduction_amount,
+        self_count: 1,
+        self_base_amount: 1500000,
+        spouse_count: @declare_user.deductible_persons.select {|s| s.spouse? }.length,
+        spouse_base_amount: 1500000,
+        dependants_count: @declare_user.deductible_persons.dependants_count,
+        dependants_base_amount: 1500000,
+        elder_count: @declare_user.deductible_persons.elder_count + (@declare_user.elder? ? 1 : 0),
+        elder_base_amount: 1000000,
+        disabled_count: @declare_user.deductible_persons.disabled_count + (@declare_user.disabled ? 1 : 0),
+        disabled_base_amount: 2000000,
+        single_parent_count: @declare_user.deductible_persons.single_parent_count + (@declare_user.single_parent ? 1 : 0),
+        single_parent_base_amount: 1000000,
+        woman_deduction_count: @declare_user.deductible_persons.woman_deduction_count + (@declare_user.woman_deduction ? 1 : 0),
+        woman_deduction_base_amount: 500000,
+      },
+      pension_deduction: {
+        total_amount: @declare_user.pensions_sum,
+        personal_pension_deduction: @declare_user.hometax_individual_income.personal_pension_deduction,
+        merchant_pension_deduction: @declare_user.hometax_individual_income.merchant_pension_deduction,
+        national_pension_deduction: @declare_user.hometax_individual_income.national_pension,
+
+      }
+    }, status: :ok
+  end
 end

--- a/app/controllers/calculated_taxes_controller.rb
+++ b/app/controllers/calculated_taxes_controller.rb
@@ -7,7 +7,7 @@ class CalculatedTaxesController < ApplicationController
       expense_ratio: @declare_user.hometax_individual_income.expenses_ratio,
       declare_from: Date.today.last_year.beginning_of_year.strftime,
       declare_to: Date.today.last_year.end_of_year.strftime,
-      declare_user: @declare_user.as_json(only: DeclareUser::JSON_FIELD),
+      declare_user: @declare_user.as_json(except: DeclareUser::EXCEPT_JSON_FIELD),
       calculated_taxes: {
         calculated_tax_by_bookkeeping: @declare_user.calculated_tax_by_bookkeeping.as_json,
         calculated_tax_by_ratio: @declare_user.calculated_tax_by_ratio.as_json,

--- a/app/controllers/calculated_taxes_controller.rb
+++ b/app/controllers/calculated_taxes_controller.rb
@@ -48,13 +48,10 @@ class CalculatedTaxesController < ApplicationController
   def tax_credits
     render json: {
       total_amount: @declare_user.tax_credit_amount,
-      tax_credits: {
-        base_tax_credit: @declare_user.base_tax_credit,
-        online_declare_credit: @declare_user.online_declare_credit,
-        children_tax_credit: @declare_user.children_tax_credit_amount,
-        newborn_baby_tax_credit: @declare_user.newborn_baby_tax_credit_amount,
-        pensions_tax_credit: @declare_user.pensions_tax_credit_amount,
-      }
+      tax_credits: @declare_user.as_json(
+        only: [],
+        methods: DeclareUser::CREDIT_METHODS
+      )
     }, status: :ok
   end
 
@@ -63,6 +60,16 @@ class CalculatedTaxesController < ApplicationController
       total_amount: @declare_user.tax_exemption_amount,
       tax_exemptions: {
       }
+    }, status: :ok
+  end
+
+  def penalty_taxes
+    render json: {
+      total_amount: @declare_user.penalty_tax_sum,
+      penalty_taxes: @declare_user.hometax_individual_income.as_json(
+        only: [],
+        methods: HometaxIndividualIncome::PENALTY_METHODS
+      )
     }, status: :ok
   end
 end

--- a/app/controllers/calculated_taxes_controller.rb
+++ b/app/controllers/calculated_taxes_controller.rb
@@ -49,6 +49,8 @@ class CalculatedTaxesController < ApplicationController
     render json: {
       total_amount: @declare_user.tax_credit_amount,
       tax_credits: {
+        base_tax_credit: @declare_user.base_tax_credit,
+        online_declare_credit: @declare_user.online_declare_credit,
         children_tax_credit_amount: @declare_user.children_tax_credit_amount,
         newborn_baby_tax_credit_amount: @declare_user.newborn_baby_tax_credit_amount,
         pensions_tax_credit_amount: @declare_user.pensions_tax_credit_amount,
@@ -60,8 +62,6 @@ class CalculatedTaxesController < ApplicationController
     render json: {
       total_amount: @declare_user.tax_exemption_amount,
       tax_exemptions: {
-        base_tax_exemption: @declare_user.base_tax_exemption,
-        online_declare_exemption: 20000,
       }
     }, status: :ok
   end

--- a/app/controllers/calculated_taxes_controller.rb
+++ b/app/controllers/calculated_taxes_controller.rb
@@ -51,9 +51,9 @@ class CalculatedTaxesController < ApplicationController
       tax_credits: {
         base_tax_credit: @declare_user.base_tax_credit,
         online_declare_credit: @declare_user.online_declare_credit,
-        children_tax_credit_amount: @declare_user.children_tax_credit_amount,
-        newborn_baby_tax_credit_amount: @declare_user.newborn_baby_tax_credit_amount,
-        pensions_tax_credit_amount: @declare_user.pensions_tax_credit_amount,
+        children_tax_credit: @declare_user.children_tax_credit_amount,
+        newborn_baby_tax_credit: @declare_user.newborn_baby_tax_credit_amount,
+        pensions_tax_credit: @declare_user.pensions_tax_credit_amount,
       }
     }, status: :ok
   end

--- a/app/controllers/declare_users_controller.rb
+++ b/app/controllers/declare_users_controller.rb
@@ -69,6 +69,6 @@ class DeclareUsersController < ApplicationController
   end
 
   def json_object
-    @declare_user.as_json(only: DeclareUser::JSON_FIELD)
+    @declare_user.as_json(except: DeclareUser::EXCEPT_JSON_FIELD)
   end
 end

--- a/app/libs/personal_deduction.rb
+++ b/app/libs/personal_deduction.rb
@@ -42,9 +42,15 @@ module PersonalDeduction
     (20 >= age || age >= 60)
   end
 
-  def default_amount
+  def default_deduction_amount
     amount = 0
+    amount += 1500000 if spouse?
     amount += 1500000 if dependant?
+    amount
+  end
+
+  def additional_deduction_amount
+    amount = 0
     amount += 2000000 if disabled
     amount += 1000000 if elder?
     amount += 1000000 if single_parent

--- a/app/libs/tax_credit_calculator.rb
+++ b/app/libs/tax_credit_calculator.rb
@@ -8,4 +8,10 @@ module TaxCreditCalculator
     return newborn_baby_size * 300000 if children_size <= 1
     return newborn_baby_size * 500000 if children_size <= 2
   end
+
+  def pensions_tax_credit_amount
+    pension_account = [hometax_individual_income.pension_account_tax_credit, 4000000].min
+    [(total_income_amount > 100000000 ? 3000000 : 4000000), hometax_individual_income.pension_account_tax_credit].min
+    ([pension_account + hometax_individual_income.retirement_pension_tax_credit, 7000000].min * 0.12).to_i
+  end
 end

--- a/app/models/declare_user.rb
+++ b/app/models/declare_user.rb
@@ -4,7 +4,7 @@ class DeclareUser < ApplicationRecord
   include TaxCreditCalculator
 
   enum status: %i(empty user deductible_persons business_expenses confirm done)
-  JSON_FIELD = %i(id name residence_number address phone_number married status)
+  EXCEPT_JSON_FIELD = %i(user_id encrypted_residence_number encrypted_residence_number_iv hometax_account)
 
   belongs_to :user
   has_many :deductible_persons, dependent: :destroy
@@ -34,9 +34,7 @@ class DeclareUser < ApplicationRecord
   end
 
   def deduction_amount
-    amount = default_amount + 1500000
-    amount -= 1500000 if dependant?
-    amount
+    1500000 + additional_deduction_amount
   end
 
   def applicable_single_parent?
@@ -106,7 +104,7 @@ class DeclareUser < ApplicationRecord
   end
 
   def tax_credit_amount
-    children_tax_credit_amount + newborn_baby_tax_credit_amount
+    children_tax_credit_amount + newborn_baby_tax_credit_amount + pensions_tax_credit_amount
   end
 
   def penalty_tax_sum

--- a/app/models/declare_user.rb
+++ b/app/models/declare_user.rb
@@ -95,16 +95,24 @@ class DeclareUser < ApplicationRecord
     deductible_persons.select { |p| p.new_born? }.length
   end
 
-  def base_tax_exemption
+  def base_tax_credit
     hometax_individual_income&.has_wage_income? ? 130000 : 70000
   end
 
-  def tax_exemption_amount
-    base_tax_exemption
+  def online_declare_credit
+    20000
   end
 
   def tax_credit_amount
-    children_tax_credit_amount + newborn_baby_tax_credit_amount + pensions_tax_credit_amount
+    base_tax_credit +
+      online_declare_credit +
+      children_tax_credit_amount +
+      newborn_baby_tax_credit_amount +
+      pensions_tax_credit_amount
+  end
+
+  def tax_exemption_amount
+    0
   end
 
   def penalty_tax_sum

--- a/app/models/declare_user.rb
+++ b/app/models/declare_user.rb
@@ -5,6 +5,7 @@ class DeclareUser < ApplicationRecord
 
   enum status: %i(empty user deductible_persons business_expenses confirm done)
   EXCEPT_JSON_FIELD = %i(user_id encrypted_residence_number encrypted_residence_number_iv hometax_account)
+  CREDIT_METHODS = %i(base_tax_credit_amount online_declare_credit_amount children_tax_credit_amount newborn_baby_tax_credit_amount pensions_tax_credit_amount)
 
   belongs_to :user
   has_many :deductible_persons, dependent: :destroy
@@ -95,17 +96,17 @@ class DeclareUser < ApplicationRecord
     deductible_persons.select { |p| p.new_born? }.length
   end
 
-  def base_tax_credit
+  def base_tax_credit_amount
     hometax_individual_income&.has_wage_income? ? 130000 : 70000
   end
 
-  def online_declare_credit
+  def online_declare_credit_amount
     20000
   end
 
   def tax_credit_amount
-    base_tax_credit +
-      online_declare_credit +
+    base_tax_credit_amount +
+      online_declare_credit_amount +
       children_tax_credit_amount +
       newborn_baby_tax_credit_amount +
       pensions_tax_credit_amount
@@ -116,7 +117,7 @@ class DeclareUser < ApplicationRecord
   end
 
   def penalty_tax_sum
-    0 || hometax_individual_income.penalty_tax_sum
+    hometax_individual_income.penalty_tax_sum
   end
 
   def prepaid_tax_sum

--- a/app/models/declare_user.rb
+++ b/app/models/declare_user.rb
@@ -62,13 +62,13 @@ class DeclareUser < ApplicationRecord
   end
 
   def pensions_sum
-    0 || hometax_individual_income.national_pension +
+    hometax_individual_income.national_pension +
       hometax_individual_income.merchant_pension_deduction +
       hometax_individual_income.personal_pension_deduction
   end
 
   def business_incomes_sum
-    0 || hometax_individual_income.business_income_sum
+    hometax_individual_income.business_income_sum
   end
 
   def simplified_bookkeeping_base_expenses
@@ -76,7 +76,7 @@ class DeclareUser < ApplicationRecord
   end
 
   def expenses_sum
-    [simplified_bookkeeping_base_expenses, 0 || hometax_individual_income.expenses_sum_by_ratio].max
+    [simplified_bookkeeping_base_expenses, hometax_individual_income.expenses_sum_by_ratio].max
   end
 
   def total_income_amount

--- a/app/models/deductible_person.rb
+++ b/app/models/deductible_person.rb
@@ -46,7 +46,7 @@ class DeductiblePerson < ApplicationRecord
     end
 
     def elder_count
-      select{ |d| d.elder == true }.length
+      select{ |d| d.elder? == true }.length
     end
 
     def disabled_count

--- a/app/models/deductible_person.rb
+++ b/app/models/deductible_person.rb
@@ -21,23 +21,44 @@ class DeductiblePerson < ApplicationRecord
   end
 
   def deduction_amount
-    amount = default_amount
-    if spouse?
-      amount += 1500000
-      amount -= 1500000 if dependant?
+    default_deduction_amount + additional_deduction_amount
+  end
+
+  class << self
+    def dependants_count
+      select{ |d| d.dependant? && !d.spouse? }.length
     end
-    amount
-  end
 
-  def self.has_spouse?
-    select{ |d| d.classification_id == 1 }.length > 0
-  end
+    def has_dependant?
+      dependants_count > 0
+    end
 
-  def self.has_dependant_children?
-    select{ |d| d.dependant_children? }.length > 0
-  end
+    def dependant_children_count
+      select{ |d| d.dependant_children? }.length
+    end
 
-  def self.has_dependant?
-    select{ |d| d.dependant? && !d.spouse? }.length > 0
+    def has_dependant_children?
+      dependant_children_count > 0
+    end
+
+    def has_spouse?
+      select{ |d| d.classification_id == 1 }.length > 0
+    end
+
+    def elder_count
+      select{ |d| d.elder == true }.length
+    end
+
+    def disabled_count
+      select{ |d| d.disabled == true }.length
+    end
+
+    def single_parent_count
+      select{ |d| d.single_parent == true }.length
+    end
+
+    def woman_deduction_count
+      select{ |d| d.woman_deduction == true }.length
+    end
   end
 end

--- a/app/models/hometax_individual_income.rb
+++ b/app/models/hometax_individual_income.rb
@@ -2,6 +2,7 @@ class HometaxIndividualIncome < ApplicationRecord
   belongs_to :declare_user
   has_many :hometax_business_incomes
   include PensionDeductionCalculator
+  PENALTY_METHODS = %w{unfaithful_business_report_amount not_issued_cash_receipts_penalty unfaithful_business_report_penalty decline_cash_receipts_penalty decline_card_penalty}
 
   def business_income_sum
     hometax_business_incomes.sum(&:income_amount)
@@ -24,23 +25,23 @@ class HometaxIndividualIncome < ApplicationRecord
   end
 
   def unfaithful_report_invoice_penalty
-    unfaithful_report_invoice_amount * 0.01
+    (unfaithful_report_invoice_amount * 0.01).to_i
   end
 
   def not_issued_cash_receipts_penalty
-    not_issued_cash_receipts_amount * 0.2
+    (not_issued_cash_receipts_amount * 0.2).to_i
   end
 
   def unfaithful_business_report_penalty
-    unfaithful_business_report_amount * 0.005
+    (unfaithful_business_report_amount * 0.005).to_i
   end
 
   def decline_cash_receipts_penalty
-    decline_cash_receipts_amount * 0.05 + decline_cash_receipts_count * 5000
+    (decline_cash_receipts_amount * 0.05 + decline_cash_receipts_count * 5000).to_i
   end
 
   def decline_card_penalty
-    decline_cards_amount * 0.05 + decline_cards_count * 5000
+    (decline_cards_amount * 0.05 + decline_cards_count * 5000).to_i
   end
 
   def expenses_sum_by_ratio

--- a/app/models/snowdon/business.rb
+++ b/app/models/snowdon/business.rb
@@ -102,18 +102,20 @@ class Snowdon::Business < Snowdon::ApplicationRecord
   end
 
   def wage
-    rows = hometax_wht_declarations
-        .where(imputed_at: 1.year.ago.all_year)
-        .to_a
+    @wage ||= begin
+      rows = hometax_wht_declarations
+          .where(imputed_at: 1.year.ago.all_year)
+          .to_a
 
-    max_declared_ats = rows
-        .group_by {|r| r.imputed_at }
-        .map {|k, vs| [k, vs.map(&:declared_at).max]}.to_h
+      max_declared_ats = rows
+          .group_by {|r| r.imputed_at }
+          .map {|k, vs| [k, vs.map(&:declared_at).max]}.to_h
 
-    rows
-        .select { |r| r.declared_at == max_declared_ats[r.imputed_at]}
-        .map { |r| (r.fulltime_employees_payments || 0) + (r.parttime_employees_payments || 0) }
-        .reduce(:+)
+      rows
+          .select { |r| r.declared_at == max_declared_ats[r.imputed_at]}
+          .map { |r| (r.fulltime_employees_payments || 0) + (r.parttime_employees_payments || 0) }
+          .reduce(:+)
+    end
   end
 
   def balance(results)

--- a/app/services/create_declare_user.rb
+++ b/app/services/create_declare_user.rb
@@ -14,30 +14,34 @@ class CreateDeclareUser < Service::Base
   def run
     ActiveRecord::Base.transaction do
       hometax_account ||= user.hometax_account || "XXXXXX"
-      declare_user = DeclareUser.create!(
+      declare_user = DeclareUser.find_or_initialize_by(
         user_id: user.id,
-        name: name,
-        residence_number: residence_number,
-        address: address,
         declare_tax_type: "income",
-        disabled: disabled,
-        single_parent: single_parent,
-        woman_deduction: woman_deduction,
-        hometax_account: hometax_account,
-        status: status || DeclareUser.statuses["user"],
-        married: married,
       )
-      hometax_individual_incomes = HometaxIndividualIncome.where(owner_id: user.owner_id)
-      if hometax_individual_incomes.blank?        
-        SlackBot.ping("#{Rails.env.development? ? "[테스트] " : ""} *세금신고오류* #{declare_user.name}님 - 신고불가: 홈택스 데이터 없음)", channel: "#labs-ops")
-        raise ActiveRecord::RecordInvalid.new(InvalidRecord.new)
-      end
-      hometax_individual_incomes.update_all(declare_user_id: declare_user.id)
-      businesses = Snowdon::Business.where(owner_id: user.owner_id)
-      businesses.each do |b|
-        next if b.hometax_business.blank?
-        simplified_bookkeepings = b.calculate(declare_user.id)
-        SimplifiedBookkeeping.upsert(rows: simplified_bookkeepings)
+      declare_user.name = name
+      declare_user.residence_number = residence_number
+      declare_user.address = address
+      declare_user.disabled = disabled
+      declare_user.single_parent = single_parent
+      declare_user.woman_deduction = woman_deduction
+      declare_user.hometax_account = hometax_account
+      declare_user.status = status || DeclareUser.statuses["user"]
+      declare_user.married = married
+      declare_user.save!
+
+      if declare_user.new_record?
+        hometax_individual_incomes = HometaxIndividualIncome.where(owner_id: user.owner_id)
+        if hometax_individual_incomes.blank?
+          SlackBot.ping("#{Rails.env.development? ? "[테스트] " : ""} *세금신고오류* #{declare_user.name}님 - 신고불가: 홈택스 데이터 없음)", channel: "#labs-ops")
+          raise ActiveRecord::RecordInvalid.new(InvalidRecord.new)
+        end
+        hometax_individual_incomes.update_all(declare_user_id: declare_user.id)
+        businesses = Snowdon::Business.where(owner_id: user.owner_id)
+        businesses.each do |b|
+          next if b.hometax_business.blank?
+          simplified_bookkeepings = b.calculate(declare_user.id)
+          SimplifiedBookkeeping.upsert(rows: simplified_bookkeepings)
+        end
       end
       declare_user
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   get "calculated_taxes/deductions", to: "calculated_taxes#deductions"
   get "calculated_taxes/tax_credits", to: "calculated_taxes#tax_credits"
   get "calculated_taxes/tax_exemptions", to: "calculated_taxes#tax_exemptions"
+  get "calculated_taxes/penalty_taxes", to: "calculated_taxes#penalty_taxes"
   get "hometax_business_incomes", to: "hometax_business_incomes#index"
   get "hometax_business_incomes/incomes", to: "hometax_business_incomes#incomes"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,9 @@ Rails.application.routes.draw do
     end
   end
   get "calculated_taxes", to: "calculated_taxes#index"
+  get "calculated_taxes/deductions", to: "calculated_taxes#deductions"
+  get "calculated_taxes/tax_credits", to: "calculated_taxes#tax_credits"
+  get "calculated_taxes/tax_exemptions", to: "calculated_taxes#tax_exemptions"
   get "hometax_business_incomes", to: "hometax_business_incomes#index"
   get "hometax_business_incomes/incomes", to: "hometax_business_incomes#incomes"
 end


### PR DESCRIPTION
- 급여금액과 복리후생비 계정과목의 비율을 체크하고
- 복리후생비 계정과목의 비용이 급여 금액의 30%가 넘어가면
- 기존 복리후생비 계정과목으로 분류된 항목들 중 금액이 작은 순으로 복리후생비 -> 기타로 계정과목 항목을 변경