### PR TITLE
AT-108 보수적인 경비처리 추가

### DIFF
--- a/app/models/declare_user.rb
+++ b/app/models/declare_user.rb
@@ -149,7 +149,7 @@ class DeclareUser < ApplicationRecord
   end
 
   def calculated_tax_by_bookkeeping
-    IndividualIncome::CalculatedTax.new(
+    @calculated_tax_by_bookkeeping ||= IndividualIncome::CalculatedTax.new(
       business_incomes: business_incomes_sum,
       expenses: simplified_bookkeeping_base_expenses,
       income_deduction: income_deduction,
@@ -161,7 +161,7 @@ class DeclareUser < ApplicationRecord
   end
     
   def calculated_tax_by_ratio
-    IndividualIncome::CalculatedTax.new(
+    @calculated_tax_by_ratio ||= IndividualIncome::CalculatedTax.new(
       business_incomes: business_incomes_sum,
       expenses: hometax_individual_income.expenses_sum_by_ratio,
       income_deduction: income_deduction,
@@ -170,6 +170,10 @@ class DeclareUser < ApplicationRecord
       penalty_tax: penalty_tax_sum,
       prepaid_tax: prepaid_tax_sum,
     )
+  end
+
+  def apply_bookkeeping?
+    calculated_tax_by_bookkeeping.payment_tax > calculated_tax_by_ratio.payment_tax
   end
 
   def snowdon_businesses
@@ -187,5 +191,9 @@ class DeclareUser < ApplicationRecord
 
   def opened_at_this_year?
     user.businesses.map{ |b| 1.year.ago.all_year === b.opened_at }.any?
+  end
+
+  def total_deduction_amount
+    deductible_persons.sum(&:deduction_amount) + deduction_amount + pensions_sum
   end
 end

--- a/app/models/simplified_bookkeeping.rb
+++ b/app/models/simplified_bookkeeping.rb
@@ -15,7 +15,7 @@ class SimplifiedBookkeeping < ApplicationRecord
         on_duplicate_key_update: {
             conflict_target: %i(registration_number vendor_registration_number purchase_type),
             index_predicate: "vendor_registration_number IS NOT NULL",
-            columns: %i(account_classification_code classification_id amount purchases_count updated_at),
+            columns: %i(account_classification_code classification_id amount purchases_count updated_at deductible),
         },
       )
     end


### PR DESCRIPTION
종합소득 내역 산출시 수입금액에 비해 과도한 지출내역이 선택되는 케이스들이 존재합니다.

이를 위해 다음과 같은 룰을 적용합니다.
- 현금영수증/세금계산서/카드사수수료 는 기본 공제처리
- 개인카드거래내역은 모두 기본 불공제
- 홈택스 카드내역은 홈택스의 값을 보고 공제/불공제를 넣어주되, 섞여 있는 사업장에 대해서는 불공제로처리

또한 기존 user_account_classification_rules의 공제처리 로직에 공제/불공제가 반영되지 않는 문제가 있어 이도 같이 반영합니다.