### PR TITLE
AT-110 기준경비율 배율적용

### DIFF
--- a/app/models/hometax_business_income.rb
+++ b/app/models/hometax_business_income.rb
@@ -7,11 +7,11 @@ class HometaxBusinessIncome < ApplicationRecord
   RATIO_FOR_SIMPLE_EXPENSE=3.2
 
   def expense_by_base_ratio
-    default_expense_by_base_ratio = (income_amount * (base_ratio_self * 0.01).round(3)).to_i
+    default_expense_by_base_ratio = (income_amount * (base_ratio_basic * 0.01).round(3)).to_i
     calculated_expnese_base_ratio = if is_simplified_bookkeeping?
-      [(expense_by_simple_ratio * RATIO_FOR_BASE_EXPENSE).to_i, default_expense_by_base_ratio].max
+      [income_amount - (income_amount * ((100 - simple_ratio_basic) * 0.01) * RATIO_FOR_BASE_EXPENSE).to_i , default_expense_by_base_ratio].max
     else
-      [(expense_by_simple_ratio * RATIO_FOR_SIMPLE_EXPENSE).to_i, default_expense_by_base_ratio].max
+      [income_amount - (income_amount * ((100 - simple_ratio_basic) * 0.01) * RATIO_FOR_SIMPLE_EXPENSE).to_i, default_expense_by_base_ratio].max
     end
     calculated_expnese_base_ratio
   end

--- a/app/models/hometax_business_income.rb
+++ b/app/models/hometax_business_income.rb
@@ -3,11 +3,24 @@ class HometaxBusinessIncome < ApplicationRecord
   scope :co_founders, ->{ where(business_type: "공동") }
   scope :freelancers, ->{ where(registration_number: [nil, '']) }
 
+  RATIO_FOR_BASE_EXPENSE=2.6
+  RATIO_FOR_SIMPLE_EXPENSE=3.2
+
   def expense_by_base_ratio
-    (income_amount * (base_ratio_self * 0.01).round(3)).to_i
+    default_expense_by_base_ratio = (income_amount * (base_ratio_self * 0.01).round(3)).to_i
+    calculated_expnese_base_ratio = if is_simplified_bookkeeping?
+      [(expense_by_simple_ratio * RATIO_FOR_BASE_EXPENSE).to_i, default_expense_by_base_ratio].max
+    else
+      [(expense_by_simple_ratio * RATIO_FOR_SIMPLE_EXPENSE).to_i, default_expense_by_base_ratio].max
+    end
+    calculated_expnese_base_ratio
   end
 
   def expense_by_simple_ratio
     (income_amount * (simple_ratio_self * 0.01).round(3)).to_i
+  end
+
+  def is_simplified_bookkeeping?
+    account_type.eql?("간편장부")
   end
 end

--- a/app/models/hometax_business_income.rb
+++ b/app/models/hometax_business_income.rb
@@ -17,7 +17,7 @@ class HometaxBusinessIncome < ApplicationRecord
   end
 
   def expense_by_simple_ratio
-    (income_amount * (simple_ratio_self * 0.01).round(3)).to_i
+    (income_amount * (simple_ratio_basic * 0.01).round(3)).to_i
   end
 
   def is_simplified_bookkeeping?

--- a/app/models/hometax_individual_income.rb
+++ b/app/models/hometax_individual_income.rb
@@ -77,13 +77,17 @@ class HometaxIndividualIncome < ApplicationRecord
     (decline_cards_amount * 0.05 + decline_cards_count * 5000).to_i
   end
 
+  def is_simple_ratio?
+    base_expense_rate.eql?("단순경비율")
+  end
+
   def expenses_sum_by_ratio
-    return hometax_business_incomes.sum(&:expense_by_base_ratio) if base_expense_rate.eql?("기준경비율")
-    hometax_business_incomes.sum(&:expense_by_simple_ratio)
+    return hometax_business_incomes.sum(&:expense_by_simple_ratio) if is_simple_ratio?
+    hometax_business_incomes.sum(&:expense_by_base_ratio)
   end
 
   def expenses_ratio
-    return hometax_business_incomes.first.base_ratio_self if base_expense_rate.eql?("기준경비율")
-    hometax_business_incomes.first.simple_ratio_self
+    return hometax_business_incomes.first.simple_ratio_basic if is_simple_ratio?
+    hometax_business_incomes.first.base_ratio_basic
   end
 end


### PR DESCRIPTION
기준 경비율 적용시 아래 룰을 따라 계산하도록 적용합니다.
`기준경비율에 의해 계산한 소득금액 >= 단순경비율에 의한 소득금액 * 간편장부대상자 2.6배, 복식부기의무자 3.2배`
이면 배율을 적용한 금액으로 산출한다.
또한 경비율 적용시 자가가 아닌 타가 경비율로 적용한다.