### PR TITLE
[AT-92] Foodtax 전자신고 파일 생성을 위한 간편장부 세액 계산 필드 채우기

### DIFF
--- a/app/libs/foodtax_helper.rb
+++ b/app/libs/foodtax_helper.rb
@@ -23,9 +23,9 @@ module FoodtaxHelper
     end
   end
 
-  def foodtax_tax_type(business)
-    if business.taxation_type == "간이과세자" then 2
-    elsif business.taxation_type == "면세사업자" then 3
+  def self.foodtax_tax_type(taxation_type)
+    if taxation_type == "간이과세자" then 2
+    elsif taxation_type == "면세사업자" then 3
     else 1
     end
   end
@@ -61,5 +61,26 @@ module FoodtaxHelper
 
   def tax_declare_due_date(year: tax_declare_year, term: tax_declare_term)
     (term == 1) ? "#{year}0131" : "#{year}1231"
+  end
+
+  def self.gijang_declare_type(declare_user)
+    if declare_user.apply_bookkeeping?
+      "20"
+    elsif declare_user.hometax_individual_income.base_expense_rate.eql?("기준경비율")
+      "31"
+    elsif declare_user.hometax_individual_income.base_expense_rate.eql?("기준경비율")
+      "32"
+    end
+  end
+
+  def self.gijang_duty_type(declare_user)
+    case declare_user.hometax_individual_income.account_type
+    when "간편장부대상자"
+      "02"
+    when "복식부기의무자"
+      "01"
+    else
+      "03"
+    end
   end
 end

--- a/app/libs/foodtax_helper.rb
+++ b/app/libs/foodtax_helper.rb
@@ -68,7 +68,7 @@ module FoodtaxHelper
       "20"
     elsif declare_user.hometax_individual_income.base_expense_rate.eql?("기준경비율")
       "31"
-    elsif declare_user.hometax_individual_income.base_expense_rate.eql?("기준경비율")
+    elsif declare_user.hometax_individual_income.base_expense_rate.eql?("단순경비율")
       "32"
     end
   end

--- a/app/libs/individual_income/calculated_tax.rb
+++ b/app/libs/individual_income/calculated_tax.rb
@@ -55,7 +55,7 @@ module IndividualIncome
     end
 
     def determined_tax
-      [calculated_tax - tax_credit - tax_exemption, 0].max 
+      [calculated_tax - limited_tax_credit -  , 0].max
     end
 
     def online_declare_credit_amount

--- a/app/libs/individual_income/calculated_tax.rb
+++ b/app/libs/individual_income/calculated_tax.rb
@@ -54,6 +54,10 @@ module IndividualIncome
       @calculated_tax ||= [0, amount.to_i].max
     end
 
+    def determined_tax
+      [calculated_tax - tax_credit - tax_exemption, 0].max
+    end
+
     def calculated_tax_with_penalty
       @calculated_tax_with_penalty ||= calculated_tax + penalty_tax
     end

--- a/app/libs/individual_income/calculated_tax.rb
+++ b/app/libs/individual_income/calculated_tax.rb
@@ -55,7 +55,7 @@ module IndividualIncome
     end
 
     def determined_tax
-      [calculated_tax - limited_tax_credit -  , 0].max
+      [calculated_tax - limited_tax_credit - tax_exemption, 0].max
     end
 
     def online_declare_credit_amount

--- a/app/models/declare_user.rb
+++ b/app/models/declare_user.rb
@@ -124,12 +124,15 @@ class DeclareUser < ApplicationRecord
   end
 
   def online_declare_credit_amount
-    0
+    if apply_bookkeeping?
+      @calculated_tax_by_bookkeeping.online_declare_credit_amount
+    else
+      @calculated_tax_by_ratio.online_declare_credit_amount
+    end
   end
 
   def tax_credit_amount
     base_tax_credit_amount +
-      online_declare_credit_amount +
       children_tax_credit_amount +
       newborn_baby_tax_credit_amount +
       pension_account_tax_credit_amount +
@@ -173,7 +176,12 @@ class DeclareUser < ApplicationRecord
   end
 
   def apply_bookkeeping?
-    calculated_tax_by_bookkeeping.payment_tax > calculated_tax_by_ratio.payment_tax
+    calculated_tax_by_bookkeeping.payment_tax < calculated_tax_by_ratio.payment_tax
+  end
+
+  def calculated_tax
+    return calculated_tax_by_bookkeeping if apply_bookkeeping?
+    calculated_tax_by_ratio
   end
 
   def snowdon_businesses

--- a/app/models/declare_user.rb
+++ b/app/models/declare_user.rb
@@ -208,4 +208,8 @@ class DeclareUser < ApplicationRecord
   def person_cd
     "P#{"%06d" % id}"
   end
+
+  def member_cd
+    "M#{"%06d" % id}"
+  end
 end

--- a/app/models/declare_user.rb
+++ b/app/models/declare_user.rb
@@ -188,4 +188,23 @@ class DeclareUser < ApplicationRecord
   def opened_at_this_year?
     user.businesses.map{ |b| 1.year.ago.all_year === b.opened_at }.any?
   end
+
+  def gijang_declare_type
+    if apply_bookkeeping?
+      "20"
+    else
+      hometax_individual_income.base_expense_rate
+    end
+  end
+
+  def gijang_duty_type
+    case hometax_individual_income.account_type
+    when "간편장부대상자"
+      "02"
+    when "복식부기의무자"
+      "01"
+    else
+      "03"
+    end
+  end
 end

--- a/app/models/deductible_person.rb
+++ b/app/models/deductible_person.rb
@@ -16,6 +16,10 @@ class DeductiblePerson < ApplicationRecord
     classification_id == 1
   end
 
+  def basic_yn?
+    classification_id == 8
+  end
+
   def single_parent?
     single_parent
   end

--- a/app/models/foodtax/cm_charge.rb
+++ b/app/models/foodtax/cm_charge.rb
@@ -6,6 +6,15 @@ module Foodtax
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
 
+    def self.find_or_initialize_by_declare_user(declare_user)
+      cm_charge = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        member_cd: declare_user.member_cd,
+        user_id: "KCD"
+      )
+      cm_charge
+    end
+
     private
 
     def default_values

--- a/app/models/foodtax/cm_member.rb
+++ b/app/models/foodtax/cm_member.rb
@@ -13,10 +13,13 @@ module Foodtax
     has_one :va_pseudo_sum, foreign_key: :member_cd, primary_key: :member_cd
 
     def self.find_or_initialize_by_declare_user(declare_user)
-      cm_member = self.find_or_initialize_by(cmpy_cd: "00025", member_cd: "M#{"%06d" % declare_user.id}")
+      cm_member = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        member_cd: declare_user.member_cd
+      )
       phone_number = declare_user.user.phone_number
       business = declare_user.businesses.first
-      cm_member.member_cd = "M#{"%06d" % declare_user.id}"
+      cm_member.member_cd = declare_user.member_cd
       cm_member.biz_addr1 = business.address.split&.first
       cm_member.biz_addr2 = business.address.split&.second
       cm_member.cp_no1 = phone_number[0..2]

--- a/app/models/foodtax/cm_member.rb
+++ b/app/models/foodtax/cm_member.rb
@@ -12,28 +12,31 @@ module Foodtax
     has_one :va_elec_file_content, foreign_key: :member_cd, primary_key: :member_cd
     has_one :va_pseudo_sum, foreign_key: :member_cd, primary_key: :member_cd
 
-    def self.initialize_with_business(business) # rubocop:disable Metrics/MethodLength
-      return if business.hometax_business.blank?
-      phone_number = business.hometax_business.phone_number || business.owner.phone_number
-      self.biz_addr1 = business.hometax_business.address.split&.first
-      self.biz_addr2 = business.hometax_business.address.split&.second
-      self.cp_no1 = phone_number[0..2]
-      self.cp_no2 = phone_number[3..6]
-      self.cp_no3 = phone_number[7..]
-      self.boss_jumin_no = "#{business.hometax_business.owner_birthday[2..]}0000001" if business.hometax_business.owner_birthday
-      self.tax_type = foodtax_tax_type(business.hometax_business)
-      self.corp_yn = (business.hometax_business.taxation_type == "법인사업자") ? "Y" : "N"
-      self.biz_reg_no = business.registration_number
-      self.trade_nm = business.hometax_business.name || business.name
-      self.boss_nm = business.hometax_business.owner_name || business.owner.name
-      self.open_dt = business.hometax_business.opened_at || Date.today.last_year.strftime("%Y%m%d")
-      self.closure_dt = business.closed_at.strftime("%Y%m%d") if business.closed_at.present?
+    def self.find_or_initialize_by_declare_user(declare_user)
+      cm_member = self.find_or_initialize_by(cmpy_cd: "00025", member_cd: "M#{"%06d" % declare_user.id}")
+      phone_number = declare_user.user.phone_number
+      business = declare_user.businesses.first
+      cm_member.member_cd = "M#{"%06d" % declare_user.id}"
+      cm_member.biz_addr1 = business.address.split&.first
+      cm_member.biz_addr2 = business.address.split&.second
+      cm_member.cp_no1 = phone_number[0..2]
+      cm_member.cp_no2 = phone_number[3..6]
+      cm_member.cp_no3 = phone_number[7..]
+      cm_member.boss_jumin_no = declare_user.residence_number
+      cm_member.tax_type = FoodtaxHelper.foodtax_tax_type(business.taxation_type)
+      cm_member.corp_yn = (business.taxation_type == "법인사업자") ? "Y" : "N"
+      cm_member.biz_reg_no = business.registration_number
+      cm_member.trade_nm = business.name
+      cm_member.boss_nm = declare_user.name
+      cm_member.open_dt = business.opened_at&.strftime("%Y%m%d") || Date.today.last_year.strftime("%Y%m%d")
+      cm_member.closure_dt = business.closed_at || ""
 
-      return if business.hometax_business.classification_code.blank?
-      division = Snowdon::HometaxBusinessClassification.find_by(code: business.hometax_business.classification_code)&.division
-      self.uptae = division if division.present?
-      self.jongmok = business.hometax_business.classification_name
-      self.upjong_cd = business.hometax_business.classification_code
+      return if business.hometax_classification_code.blank?
+      division = Snowdon::HometaxBusinessClassification.find_by(code: business.hometax_classification_code)&.division
+      cm_member.uptae = division if division.present?
+      cm_member.jongmok = business.hometax_classification_name
+      cm_member.upjong_cd = business.hometax_classification_code
+      cm_member
     end
 
     def business_id
@@ -44,11 +47,9 @@ module Foodtax
 
     def default_values
       self.cmpy_cd ||= "00025"
-      self.boss_jumin_no = "0000000000001" if boss_jumin_no.blank?
       self.combiz_yn = "N" if combiz_yn.blank?
       self.use_yn = "Y" if use_yn.blank?
       self.taxaccept_yn = "N" if taxaccept_yn.blank?
-      self.closure_dt = "" if closure_dt.blank?
     end
   end
 end

--- a/app/models/foodtax/cm_member.rb
+++ b/app/models/foodtax/cm_member.rb
@@ -22,9 +22,11 @@ module Foodtax
       cm_member.member_cd = declare_user.member_cd
       cm_member.biz_addr1 = business.address.split&.first
       cm_member.biz_addr2 = business.address.split&.second
-      cm_member.cp_no1 = phone_number[0..2]
-      cm_member.cp_no2 = phone_number[3..6]
-      cm_member.cp_no3 = phone_number[7..]
+      if phone_number
+        cm_member.cp_no1 = phone_number[0..2]
+        cm_member.cp_no2 = phone_number[3..6]
+        cm_member.cp_no3 = phone_number[7..]
+      end
       cm_member.boss_jumin_no = declare_user.residence_number
       cm_member.tax_type = FoodtaxHelper.foodtax_tax_type(business.taxation_type)
       cm_member.corp_yn = (business.taxation_type == "법인사업자") ? "Y" : "N"

--- a/app/models/foodtax/cm_member.rb
+++ b/app/models/foodtax/cm_member.rb
@@ -41,6 +41,10 @@ module Foodtax
       cm_member.uptae = division if division.present?
       cm_member.jongmok = business.hometax_classification_name
       cm_member.upjong_cd = business.hometax_classification_code
+      cm_member.bank_cd = ""
+      cm_member.acct_no = ""
+      cm_member.bangi_yn = "X"
+      cm_member.biz_yn = "Y"
       cm_member
     end
 

--- a/app/models/foodtax/ic_business_income_wht.rb
+++ b/app/models/foodtax/ic_business_income_wht.rb
@@ -2,6 +2,21 @@ module Foodtax
   class IcBusinessIncomeWht < Foodtax::ApplicationRecord
     include FoodtaxHelper
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :seq_no
-    self.table_name = "ic_1022"    
+    self.table_name = "ic_1022"
+
+    def initialize(declare_user, cm_member)
+      self.cmpy_cd = "00025"
+      self.person_cd = "P#{"%06d" % declare_user.id}"
+      self.term_cd = "2019"
+      self.declare_seq = "1"
+      self.seq_no = "1"
+      self.trade_nm = cm_member.biz_trade_nm
+      self.biz_reg_no = cm_member.biz_reg_no
+      self.jumin_no = declare_user.residence_number
+      self.withholding_income = 0
+      self.withholding_local = 0
+      self.withholding_nong = 0
+      self.biz_yn = "Y"
+    end
   end
 end

--- a/app/models/foodtax/ic_family.rb
+++ b/app/models/foodtax/ic_family.rb
@@ -14,9 +14,7 @@ module Foodtax
           .deductible_persons
           .to_a
           .each_with_index
-          .map do |p, i|
-        initialize_by_deductible_person(p, person_cd, i)
-      end
+          .map {| p, i | initialize_by_deductible_person(p, person_cd, "#{i + 1}") }
     end
 
     def initialize_by_deductible_person(deductible_person,

--- a/app/models/foodtax/ic_family.rb
+++ b/app/models/foodtax/ic_family.rb
@@ -7,6 +7,18 @@ module Foodtax
     belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
 
 
+    def initializes_by_declare_user(declare_user)
+      person_cd = "P#{"%06d" % declare_user.id}"
+
+      declare_user
+          .deductible_persons
+          .to_a
+          .each_with_index
+          .map do |p, i|
+        initialize_by_deductible_person(p, person_cd, i)
+      end
+    end
+
     def initialize_by_deductible_person(deductible_person,
                                         person_cd,
                                         seq_no)

--- a/app/models/foodtax/ic_family.rb
+++ b/app/models/foodtax/ic_family.rb
@@ -1,9 +1,40 @@
 module Foodtax
   class IcFamily < Foodtax::ApplicationRecord
     include FoodtaxHelper
-    self.primary_keys = :member_cd, :cmpy_cd, :term_cd, :declare_seq, :seq_no    
+    self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :seq_no
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
     belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
+
+
+    def initialize_by_deductible_person(deductible_person,
+                                        person_cd,
+                                        seq_no)
+      self.cmpy_cd = "00025"
+      self.person_cd = person_cd
+      self.term_cd = "2019"
+      self.declare_seq = "1"
+      self.seq_no = seq_no
+      self.jumin_no = deductible_person.residence_number
+      self.name = deductible_person.name
+      self.relation_cd = deductible_person.classification.slug
+      self.relation_nm = deductible_person.relation_name
+      self.senior_yn = deductible_person.elder? ? "Y" : "N"
+      self.disabled_yn = deductible_person.disabled ? "Y": "N"
+      self.women_yn = deductible_person.woman_deduction? ? "Y" : "N"
+      self.child6_yn = "N"
+      self.oneparent_yn = deductible_person.single_parent? ? "Y" : "N"
+      self.native_cd = "1"
+      self.basic_yn = deductible_person.basic_yn? ? "Y" : "N"
+      self.delivery_yn = deductible_person.new_born? ? "Y" : "N"
+      self.partner_yn = deductible_person.spouse? ? "Y" : "N"
+      self.resident_yn = "1"
+      self.insu_yn = "N"
+      self.medi_yn = "N"
+      self.edu_yn = "N"
+      self.card_yn = "N"
+      self.children_yn = deductible_person.dependant_children? ? "Y" : "N"
+      self.resident_national_cd = "KR"
+    end
   end
 end

--- a/app/models/foodtax/ic_family.rb
+++ b/app/models/foodtax/ic_family.rb
@@ -5,7 +5,8 @@ module Foodtax
 
     belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
 
-    def self.import_by_declare_user(declare_user)
+    def self.import(declare_user)
+      self.import_self(declare_user)
       declare_user
         .deductible_persons
         .to_a
@@ -15,8 +16,39 @@ module Foodtax
           declare_user.person_cd,
           "#{1.year.ago.year}",
           "1",
-          "#{i + 1}").save!
+          "#{i + 2}").save!
       }
+    end
+
+    def self.import_self(declare_user)
+      ic_family = self.find_or_initialize_by(
+          cmpy_cd: "00025",
+          person_cd: declare_user.person_cd,
+          term_cd: "#{1.year.ago.year}",
+          declare_seq: "1",
+          seq_no: "1")
+      ic_family.seq_no = "1"
+      ic_family.jumin_no = declare_user.residence_number
+      ic_family.name = declare_user.name
+      ic_family.relation_cd = "0"
+      ic_family.relation_nm = "소득자의 본인"
+      ic_family.senior_yn = declare_user.elder? ? "Y" : "N"
+      ic_family.disabled_yn = declare_user.disabled ? "Y": "N"
+      ic_family.women_yn = declare_user.woman_deduction? ? "Y" : "N"
+      ic_family.child6_yn = "N"
+      ic_family.oneparent_yn = declare_user.single_parent? ? "Y" : "N"
+      ic_family.native_cd = "1"
+      ic_family.basic_yn = "Y"
+      ic_family.delivery_yn = "0"
+      ic_family.partner_yn = "N"
+      ic_family.resident_yn = "1"
+      ic_family.insu_yn = "N"
+      ic_family.medi_yn = "N"
+      ic_family.edu_yn = "N"
+      ic_family.card_yn = "N"
+      ic_family.children_yn = "N"
+      ic_family.resident_national_cd = "KR"
+      ic_family.save!
     end
 
     def self.find_or_initialize_by_deductible_person(deductible_person,
@@ -41,7 +73,7 @@ module Foodtax
       ic_family.child6_yn = "N"
       ic_family.oneparent_yn = deductible_person.single_parent? ? "Y" : "N"
       ic_family.native_cd = "1"
-      ic_family.basic_yn = deductible_person.basic_yn? ? "Y" : "N"
+      ic_family.basic_yn = "Y"
       ic_family.delivery_yn = deductible_person.new_born? ? "#{declare_user.new_born_children_or_adopted_count}" : "0"
       ic_family.partner_yn = deductible_person.spouse? ? "Y" : "N"
       ic_family.resident_yn = "1"

--- a/app/models/foodtax/ic_family.rb
+++ b/app/models/foodtax/ic_family.rb
@@ -6,7 +6,9 @@ module Foodtax
     belongs_to :ic_person, foreign_key: :person_cd
 
     def self.import_by_declare_user(declare_user)
-      self.import!(declare_user.deductible_persons
+      self.import!(
+        declare_user
+          .deductible_persons
           .to_a
           .each_with_index
           .map {| p, i | self.find_or_initialize_by_deductible_person(

--- a/app/models/foodtax/ic_family.rb
+++ b/app/models/foodtax/ic_family.rb
@@ -3,48 +3,54 @@ module Foodtax
     include FoodtaxHelper
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :seq_no
 
-    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
+    belongs_to :ic_person, foreign_key: :person_cd
 
-
-    def initializes_by_declare_user(declare_user)
-      person_cd = "P#{"%06d" % declare_user.id}"
-
-      declare_user
-          .deductible_persons
+    def self.import_by_declare_user(declare_user)
+      self.import!(declare_user.deductible_persons
           .to_a
           .each_with_index
-          .map {| p, i | initialize_by_deductible_person(p, person_cd, "#{i + 1}") }
+          .map {| p, i | self.find_or_initialize_by_deductible_person(
+            p,
+            declare_user.person_cd,
+            "#{1.year.ago.year}",
+            "1",
+            "#{i + 1}")
+        }
+      )
     end
 
-    def initialize_by_deductible_person(deductible_person,
+    def self.find_or_initialize_by_deductible_person(deductible_person,
                                         person_cd,
+                                        term_cd,
+                                        declare_seq,
                                         seq_no)
-      self.cmpy_cd = "00025"
-      self.person_cd = person_cd
-      self.term_cd = "2019"
-      self.declare_seq = "1"
-      self.seq_no = seq_no
-      self.jumin_no = deductible_person.residence_number
-      self.name = deductible_person.name
-      self.relation_cd = deductible_person.classification.slug
-      self.relation_nm = deductible_person.relation_name
-      self.senior_yn = deductible_person.elder? ? "Y" : "N"
-      self.disabled_yn = deductible_person.disabled ? "Y": "N"
-      self.women_yn = deductible_person.woman_deduction? ? "Y" : "N"
-      self.child6_yn = "N"
-      self.oneparent_yn = deductible_person.single_parent? ? "Y" : "N"
-      self.native_cd = "1"
-      self.basic_yn = deductible_person.basic_yn? ? "Y" : "N"
-      self.delivery_yn = deductible_person.new_born? ? "Y" : "N"
-      self.partner_yn = deductible_person.spouse? ? "Y" : "N"
-      self.resident_yn = "1"
-      self.insu_yn = "N"
-      self.medi_yn = "N"
-      self.edu_yn = "N"
-      self.card_yn = "N"
-      self.children_yn = deductible_person.dependant_children? ? "Y" : "N"
-      self.resident_national_cd = "KR"
+      ic_family = self.find_or_initialize_by(
+          cmpy_cd: "00025",
+          person_cd: person_cd,
+          term_cd: term_cd,
+          declare_seq: declare_seq)
+      ic_family.seq_no = seq_no
+      ic_family.jumin_no = deductible_person.residence_number
+      ic_family.name = deductible_person.name
+      ic_family.relation_cd = deductible_person.classification.slug
+      ic_family.relation_nm = deductible_person.relation_name
+      ic_family.senior_yn = deductible_person.elder? ? "Y" : "N"
+      ic_family.disabled_yn = deductible_person.disabled ? "Y": "N"
+      ic_family.women_yn = deductible_person.woman_deduction? ? "Y" : "N"
+      ic_family.child6_yn = "N"
+      ic_family.oneparent_yn = deductible_person.single_parent? ? "Y" : "N"
+      ic_family.native_cd = "1"
+      ic_family.basic_yn = deductible_person.basic_yn? ? "Y" : "N"
+      ic_family.delivery_yn = deductible_person.new_born? ? "Y" : "N"
+      ic_family.partner_yn = deductible_person.spouse? ? "Y" : "N"
+      ic_family.resident_yn = "1"
+      ic_family.insu_yn = "N"
+      ic_family.medi_yn = "N"
+      ic_family.edu_yn = "N"
+      ic_family.card_yn = "N"
+      ic_family.children_yn = deductible_person.dependant_children? ? "Y" : "N"
+      ic_family.resident_national_cd = "KR"
+      ic_family
     end
   end
 end

--- a/app/models/foodtax/ic_head.rb
+++ b/app/models/foodtax/ic_head.rb
@@ -68,10 +68,11 @@ module Foodtax
       ic_head.house_cnt = "0"
       ic_head.std_tax_deduct_yn = "N"
 
-      ic_head.biz_income_amt = declare_user.business_incomes_sum
+      ic_head.biz_income_amt = [declare_user.total_income_amount, 0].max
       ic_head.salary_sale_amt = "0"
-      ic_head.total_sale_amt = declare_user.expenses_sum
-      ic_head.income_amt = declare_user.total_income_amount
+      ic_head.total_sale_amt = declare_user.business_incomes_sum
+      ic_head.income_amt = [declare_user.total_income_amount, 0].max
+
       ic_head.deduct_amt = declare_user.total_deduction_amount
       ic_head.income_standard_amt = calculated_tax.base_taxation
       ic_head.income_rate = calculated_tax.tax_rate

--- a/app/models/foodtax/ic_head.rb
+++ b/app/models/foodtax/ic_head.rb
@@ -60,13 +60,13 @@ module Foodtax
 
       ic_head.resident_yn = "Y"
       ic_head.resident_national_cd = "KR"
-      ic_head.foreign_yn = declare_user.is_local? ? "Y" : "N"
+      ic_head.foreign_yn = declare_user.is_local? ? "N" : "Y"
       ic_head.foregn_simple_rate_yn = "N"
       ic_head.employ_yn = "N"
       ic_head.house_nonsep_force_yn = "N"
-      ic_head.house_lease_sep_yn = "N"
+      ic_head.house_lease_sep_yn = "X"
       ic_head.house_cnt = "0"
-      ic_head.std_tax_deduct_yn = "Y"
+      ic_head.std_tax_deduct_yn = "N"
 
       ic_head.biz_income_amt = declare_user.business_incomes_sum
       ic_head.salary_sale_amt = "0"

--- a/app/models/foodtax/ic_head.rb
+++ b/app/models/foodtax/ic_head.rb
@@ -2,6 +2,8 @@ module Foodtax
   class IcHead < Foodtax::ApplicationRecord
     include FoodtaxHelper
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq
+    after_initialize :initialize_local_taxes
+    after_initialize :initialize_rural_taxes
 
     def declare_file      
       results = Foodtax::IcHead.execute_procedure :sp_ic_head_file_gen_only_hometax,
@@ -13,6 +15,146 @@ module Foodtax
         login_user_id: 'KCD',
         return_val1: ''
       Base64.encode64(results.flatten.first["result"].force_encoding("UTF-8").encode("EUC-KR"))
+    end
+
+    def self.find_or_initialize_by_declare_user(ic_person, declare_user, calculated_tax)
+      ic_head = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1",
+        declare_type: "01"
+      )
+      ic_head.hometax_id = declare_user.hometax_account
+      ic_head.submit_yyyymm = Date.today.strftime("%Y%m")
+      ic_head.return_bank = declare_user.bank_code || ""
+      ic_head.return_acct_no = declare_user.bank_account_number || ""
+      ic_head.return_bank_type = ""
+      ic_head.self_declare_yn = "Y"
+      ic_head.cta_cmpy_cd = "40000"
+      address = declare_user.hometax_address || declare_user.address
+      split_address = address.split
+      ic_head.addr1 = split_address[0] || ""
+      ic_head.addr2 = split_address[1] || ""
+      ic_head.addr3 = split_address[2..]&.join(" ") || ""
+
+      ic_head.dong_cd = ""
+      ic_head.taxoffice_cd = ""
+      ic_head.jumin_location_nm = ""
+
+      ic_head.term_str_dt = 1.year.ago.beginning_of_year.strftime("%Y%m%d")
+      ic_head.term_end_dt = 1.year.ago.end_of_year.strftime("%Y%m%d")
+      ic_head.pre_term_str_dt = 2.year.ago.beginning_of_year.strftime("%Y%m%d")
+      ic_head.pre_term_end_dt = 2.year.ago.end_of_year.strftime("%Y%m%d")
+      ic_head.write_dt = "20200601"
+      ic_head.declare_due_dt = "20200601"
+      ic_head.simple_rate_yn = "N"
+      ic_head.addr_tel_no = ic_person.tel_no
+      ic_head.biz_tel_no = ic_person.tel_no
+      ic_head.cp_no = ic_person.tel_no
+      ic_head.email = ""
+      ic_head.gijang_declare_type = FoodtaxHelper.gijang_declare_type(declare_user)
+      ic_head.gijang_duty_type = FoodtaxHelper.gijang_duty_type(declare_user)
+      ic_head.daeri_type = "1"
+      ic_head.jumin_location_nm = ""
+
+      ic_head.resident_yn = "Y"
+      ic_head.resident_national_cd = "KR"
+      ic_head.foreign_yn = declare_user.is_local? ? "Y" : "N"
+      ic_head.foregn_simple_rate_yn = "N"
+      ic_head.employ_yn = "N"
+      ic_head.house_nonsep_force_yn = "N"
+      ic_head.house_lease_sep_yn = "N"
+      ic_head.house_cnt = "0"
+      ic_head.std_tax_deduct_yn = "Y"
+
+      ic_head.biz_income_amt = declare_user.business_incomes_sum
+      ic_head.salary_sale_amt = "0"
+      ic_head.total_sale_amt = declare_user.expenses_sum
+      ic_head.income_amt = declare_user.total_income_amount
+      ic_head.deduct_amt = declare_user.total_deduction_amount
+      ic_head.income_standard_amt = calculated_tax.base_taxation
+      ic_head.income_rate = calculated_tax.tax_rate
+      ic_head.income_yieldtax_amt = calculated_tax.calculated_tax
+      ic_head.income_taxgam_amt = calculated_tax.limited_tax_exemption
+      ic_head.income_taxgong_amt = calculated_tax.limited_tax_credit
+
+      ic_head.income_decisiontax_jong_amt = calculated_tax.determined_tax
+      ic_head.income_decisiontax_sep_amt = 0
+      ic_head.income_decisiontax_amt = calculated_tax.determined_tax
+
+      ic_head.income_addtax_amt = declare_user.penalty_tax_sum
+      ic_head.income_addpaytax_amt = 0
+      ic_head.income_total_amt = calculated_tax.determined_tax
+
+
+      ic_head.income_prepay_amt = declare_user.hometax_individual_income.prepaid_tax
+      ic_head.income_paytax_amt = calculated_tax.payment_tax
+
+      ic_head.income_special_minus = 0
+      ic_head.income_special_add = 0
+      ic_head.income_septax_amt = 0
+      ic_head.income_due_paytax_amt = calculated_tax.payment_tax
+      ic_head.compare_cd = "1"
+
+
+      ic_head.addtax_deny_cd = ""
+      ic_head.addtax_gam_cd = 0
+      ic_head.autocal_yn_nogijang = "Y"
+      ic_head.autocal_yn_gijangdeduct = "X"
+      ic_head.close_yn = "N"
+      ic_head.close_dt = ""
+      ic_head.close_user_id = ""
+      ic_head.file_make_yn = "N"
+      ic_head.file_make_dt = ""
+      ic_head.file_make_cnt = 0
+      ic_head.file_make_user_id = ""
+      ic_head
+    end
+
+    private
+
+    def initialize_rural_taxes
+      self.nong_standard_amt = 0
+      self.nong_rate = 0
+      self.nong_yieldtax_amt = 0
+      self.nong_decisiontax_jong_amt = 0
+      self.nong_decisiontax_sep_amt = 0
+      self.nong_decisiontax_amt = 0
+      self.nong_addtax_amt = 0
+      self.nong_refund_amt = 0
+      self.nong_total_amt = 0
+      self.nong_prepay_amt = 0
+      self.nong_paytax_amt = 0
+      self.nong_septax_amt = 0
+      self.nong_due_paytax_amt = 0
+    end
+
+    def initialize_local_taxes
+      self.local_standard_amt = 0
+      self.local_rate = 0
+      self.local_taxgam_amt = 0
+      self.local_taxgong_amt = 0
+      self.local_yieldtax_amt = 0
+      self.local_decisiontax_jong_amt = 0
+      self.local_decisiontax_sep_amt = 0
+      self.local_decisiontax_amt = 0
+      self.local_nor_nondeclare_addtax_amt = 0
+      self.local_den_nondeclare_addtax_amt = 0
+      self.local_nor_mindeclare_addtax_amt = 0
+      self.local_den_mindeclare_addtax_amt = 0
+      self.local_declare_addtax_amt = 0
+      self.local_delay_day_cnt = 0
+      self.local_delay_addtax_amt = 0
+      self.local_nogigang_addtax_amt = 0
+      self.local_etc_addtax_amt = 0
+      self.local_etc_addtax_sum_amt = 0
+      self.local_addtax_sum_amt = 0
+      self.local_special_prepay_amt = 0
+      self.local_random_prepay_amt = 0
+      self.local_realpay_amt = 0
+      self.local_addpaytax_amt = 0
+      self.local_total_amt = 0
     end
   end
 end

--- a/app/models/foodtax/ic_income.rb
+++ b/app/models/foodtax/ic_income.rb
@@ -1,16 +1,45 @@
 module Foodtax
   class IcIncome < Foodtax::ApplicationRecord
     include FoodtaxHelper
-    self.primary_keys = :member_cd, :cmpy_cd, :term_cd, :declare_seq
+    self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :seq_no
     self.table_name = "VA_ELEC_FILE_CONTENTS"
     after_initialize :default_user_id
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
     belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
 
-    private
-
-    def default_user_id
+    def initialize(declare_user,
+                   cm_member)
+      self.cmpy_cd = "00025"
+      self.person_cd = "P#{"%06d" % declare_user.id}"
+      self.term_cd = "2019"
+      self.declare_seq = "1"
+      self.seq_no = "1"
+      self.member_cd = cm_member.member_cd
+      self.income_type = "40"
+      self.biz_addr = declare_user.hometax_address
+      self.biz_native_yn = "Y"
+      self.biz_national_cd = "KR"
+      self.biz_trade_nm = cm_member.biz_trade_nm
+      self.biz_reg_no = cm_member.biz_reg_no
+      self.term_str_dt = "20190101"
+      self.term_end_dt = "20191231"
+      self.biz_tel_no = "--"
+      self.gijang_declare_type = declare_user.gijang_declare_type
+      self.gijang_duty_type = declare_user.gijang_duty_type
+      self.upjong_cd = cm_member.upjong_cd
+      self.total_sale_amt = declare_user.business_incomes_sum
+      self.total_cost_amt = declare_user.expenses_sum
+      self.income_amt = declare_user.total_income_amount
+      self.combiz_yn = cm_member.combiz_yn
+      self.comboss_yn = "N"
+      self.comboss_jumin_no = ""
+      self.comboss_type = ""
+      self.comboss_name = ""
+      self.withholding_income = 0
+      self.withholding_nong = 0
+      self.biz_yn = "Y"
+      self.apply_yn = "Y"
     end
   end
 end

--- a/app/models/foodtax/ic_income.rb
+++ b/app/models/foodtax/ic_income.rb
@@ -2,44 +2,51 @@ module Foodtax
   class IcIncome < Foodtax::ApplicationRecord
     include FoodtaxHelper
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :seq_no
-    self.table_name = "VA_ELEC_FILE_CONTENTS"
+    self.table_name = "ic_income"
     after_initialize :default_user_id
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
 
-    def initialize(declare_user,
-                   cm_member)
-      self.cmpy_cd = "00025"
-      self.person_cd = "P#{"%06d" % declare_user.id}"
-      self.term_cd = "2019"
-      self.declare_seq = "1"
-      self.seq_no = "1"
-      self.member_cd = cm_member.member_cd
-      self.income_type = "40"
-      self.biz_addr = declare_user.hometax_address
-      self.biz_native_yn = "Y"
-      self.biz_national_cd = "KR"
-      self.biz_trade_nm = cm_member.biz_trade_nm
-      self.biz_reg_no = cm_member.biz_reg_no
-      self.term_str_dt = "20190101"
-      self.term_end_dt = "20191231"
-      self.biz_tel_no = "--"
-      self.gijang_declare_type = declare_user.gijang_declare_type
-      self.gijang_duty_type = declare_user.gijang_duty_type
-      self.upjong_cd = cm_member.upjong_cd
-      self.total_sale_amt = declare_user.business_incomes_sum
-      self.total_cost_amt = declare_user.expenses_sum
-      self.income_amt = declare_user.total_income_amount
-      self.combiz_yn = cm_member.combiz_yn
-      self.comboss_yn = "N"
-      self.comboss_jumin_no = ""
-      self.comboss_type = ""
-      self.comboss_name = ""
-      self.withholding_income = 0
-      self.withholding_nong = 0
-      self.biz_yn = "Y"
-      self.apply_yn = "Y"
+    def self.find_or_initialize_by_declare_user(declare_user, cm_member)
+      ic_income = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1",
+        member_cd: cm_member.member_cd,
+      )
+      ic_income.cmpy_cd = "00025"
+      ic_income.person_cd = declare_user.person_cd
+      ic_income.term_cd = "2019"
+      ic_income.declare_seq = "1"
+      ic_income.seq_no = "1"
+      ic_income.member_cd = cm_member.member_cd
+      ic_income.income_type = "40"
+      ic_income.biz_addr = "#{cm_member.biz_addr1} #{cm_member.biz_addr2}"
+      ic_income.biz_native_yn = "Y"
+      ic_income.biz_national_cd = "KR"
+      ic_income.biz_trade_nm = cm_member.trade_nm
+      ic_income.biz_reg_no = cm_member.biz_reg_no
+      ic_income.term_str_dt = "20190101"
+      ic_income.term_end_dt = "20191231"
+      ic_income.biz_tel_no = "--"
+      ic_income.gijang_declare_type = FoodtaxHelper.gijang_declare_type(declare_user)
+      ic_income.gijang_duty_type = FoodtaxHelper.gijang_duty_type(declare_user)
+      ic_income.upjong_cd = cm_member.upjong_cd
+      ic_income.total_sale_amt = declare_user.business_incomes_sum
+      ic_income.total_cost_amt = declare_user.expenses_sum
+      ic_income.income_amt = declare_user.total_income_amount
+      ic_income.combiz_yn = cm_member.combiz_yn
+      ic_income.comboss_yn = "N"
+      ic_income.comboss_jumin_no = ""
+      ic_income.comboss_type = ""
+      ic_income.comboss_name = ""
+      ic_income.withholding_income = 0
+      ic_income.withholding_nong = 0
+      ic_income.biz_yn = "Y"
+      ic_income.apply_yn = "Y"
+      ic_income
     end
   end
 end

--- a/app/models/foodtax/ic_income_deduction.rb
+++ b/app/models/foodtax/ic_income_deduction.rb
@@ -3,14 +3,159 @@ module Foodtax
     include FoodtaxHelper
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :gonggam_cd
     self.table_name = "ic_1060"
-    after_initialize :default_user_id
+    
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
 
-    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
+    def self.find_or_initialize_by_declare_user(declare_user, gonggam_cd)
+      ic_income_deduction = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1",
+        gonggam_cd: gonggam_cd,
+      )
+    end
 
-    private
+    def self.import_deductions(declare_user)
+      self_deduction = self.find_or_initialize_by_declare_user(
+        declare_user,
+        "F01"
+      )
+      self_deduction.create_deduction(0, 1, 1500000)
 
-    def default_user_id
+      spouse_count = declare_user
+                      .deductible_persons
+                      .select {|s| s.spouse? }
+                      .length
+      if spouse_count > 0
+        spouse_deduction = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "F02"
+        )
+        spouse_deduction.create_deduction(0, 1, 1500000)
+      end
+
+      dependants_count = declare_user.deductible_persons.dependants_count
+      if dependants_count > 0
+        dependants_deduction = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "F03"
+        )
+        dependants_deduction.create_deduction(
+          0,
+          dependants_count,
+          1500000 * dependants_count
+        )
+      end
+
+      elder_count = declare_user
+                      .deductible_persons
+                      .elder_count +
+                      (declare_user.elder? ? 1 : 0)
+
+      if elder_count > 0
+        elder_deduction = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "F05"
+        )
+        elder_deduction.create_deduction(
+          0,
+          elder_count,
+          1000000 * elder_count
+        )
+      end
+
+      disabled_count = declare_user
+                        .deductible_persons
+                        .disabled_count +
+                        (declare_user.disabled ? 1 : 0)
+
+      if disabled_count > 0
+        disabled_deduction = self.find_or_initialize_by_declare_user(
+          declare_user, 
+          "F06"
+        )
+        disabled_deduction.create_deduction(
+          0,
+          disabled_count,
+          2000000 * disabled_count
+        )
+      end
+
+      if declare_user.woman_deduction?
+        woman_deduction = self.find_or_initialize_by_declare_user(
+          declare_user, 
+          "F07"
+        )
+        woman_deduction.create_deduction(0, 1, 500000)
+      end
+
+      if declare_user.single_parent?
+        single_parent_deduction = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "F14"
+        )
+        single_parent_deduction.create_deduction(0, 1, 1000000)
+      end
+
+      personal_deduction_amount = declare_user
+                                    .deductible_persons.sum(&:deduction_amount) + 
+                                    declare_user
+                                      .deduction_amount
+      if personal_deduction_amount > 0
+        personal_deduction = self.find_or_initialize_by_declare_user(
+          declare_user, 
+          "F29"
+        )
+        personal_deduction.create_deduction(personal_deduction_amount, 0, 0)
+      end
+
+      national_pension_deduction_amount = declare_user
+                                            .hometax_individual_income
+                                            .national_pension
+
+      if national_pension_deduction_amount > 0
+        national_pension = self.find_or_initialize_by_declare_user(
+          declare_user, 
+          "F31"
+        )
+        national_pension.create_deduction(national_pension_deduction_amount, 0, 0)
+      end
+
+      personal_pension_deduction = declare_user
+                                    .hometax_individual_income
+                                    .personal_pension_deduction
+      merchant_pension_deduction = declare_user
+                                    .hometax_individual_income
+                                    .merchant_pension_deduction
+
+      special_deduction_amount = personal_pension_deduction + merchant_pension_deduction
+      if special_deduction_amount > 0
+        special_deduction = self.find_or_initialize_by_declare_user(
+          declare_user, 
+          "F59"
+        )
+        special_deduction.create_deduction(special_deduction_amount, 0, 0)
+      end
+
+      total_amount = personal_deduction_amount +
+                      special_deduction_amount +
+                      national_pension_deduction_amount
+
+      if total_amount > 0
+        total_deduction = self.find_or_initialize_by_declare_user(
+          declare_user, 
+          "199"
+        )
+        total_deduction.create_deduction(total_amount, 0, 0)
+      end
+    end
+
+    def create_deduction(amount, person_count, person_amount)
+      self.deduct_amt = amount
+      self.person_cnt = person_count
+      self.person_amt = person_amount
+      save!
     end
   end
 end

--- a/app/models/foodtax/ic_income_deduction.rb
+++ b/app/models/foodtax/ic_income_deduction.rb
@@ -108,6 +108,7 @@ module Foodtax
           "F29"
         )
         personal_deduction.create_deduction(personal_deduction_amount, 0, 0)
+        Foodtax::IcPensionIncomeDeduction.create_personal_pension(declare_user)
       end
 
       national_pension_deduction_amount = declare_user

--- a/app/models/foodtax/ic_income_deduction.rb
+++ b/app/models/foodtax/ic_income_deduction.rb
@@ -137,6 +137,8 @@ module Foodtax
           "F59"
         )
         special_deduction.create_deduction(special_deduction_amount, 0, 0)
+        ic_special_taxation_income_deduction =
+          Foodtax::IcSpecialTaxationIncomeDeduction.import_deductions(declare_user)
       end
 
       total_amount = personal_deduction_amount +

--- a/app/models/foodtax/ic_income_details_sum.rb
+++ b/app/models/foodtax/ic_income_details_sum.rb
@@ -1,16 +1,24 @@
 module Foodtax
   class IcIncomeDetailsSum < Foodtax::ApplicationRecord
     include FoodtaxHelper
-    self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :income_type, :seq_no
+    self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :income_type
     self.table_name = "ic_1040"
-    after_initialize :default_user_id
 
-    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
-
-    private
-
-    def default_user_id
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
+    def self.find_or_initialize_by_declare_user(declare_user)
+      ic_income_detail_sum = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1",
+        income_type: "40"
+      )
+      ic_income_detail_sum.C0010 = declare_user.total_income_amount
+      ic_income_detail_sum.C0020 = 0
+      ic_income_detail_sum.C0030 = 0
+      ic_income_detail_sum.C0040 = 0
+      ic_income_detail_sum.C0050 = declare_user.total_income_amount < 0 ? 0 : declare_user.total_income_amount
+      ic_income_detail_sum
     end
   end
 end

--- a/app/models/foodtax/ic_income_details_sum.rb
+++ b/app/models/foodtax/ic_income_details_sum.rb
@@ -17,7 +17,7 @@ module Foodtax
       ic_income_detail_sum.C0020 = 0
       ic_income_detail_sum.C0030 = 0
       ic_income_detail_sum.C0040 = 0
-      ic_income_detail_sum.C0050 = declare_user.total_income_amount < 0 ? 0 : declare_user.total_income_amount
+      ic_income_detail_sum.C0050 = [declare_user.total_income_amount, 0].max
       ic_income_detail_sum
     end
   end

--- a/app/models/foodtax/ic_pension_income_bank.rb
+++ b/app/models/foodtax/ic_pension_income_bank.rb
@@ -1,0 +1,15 @@
+module Foodtax
+  class IcPensionIncomeBank < Foodtax::ApplicationRecord
+    include FoodtaxHelper
+    self.primary_keys = :bank_cd
+    self.table_name = "ic_1232_bank"
+    after_initialize :default_dates, :default_user_id
+    private
+
+    def default_dates
+    end
+
+    def default_user_id
+    end
+  end
+end

--- a/app/models/foodtax/ic_pension_income_deduction.rb
+++ b/app/models/foodtax/ic_pension_income_deduction.rb
@@ -1,0 +1,97 @@
+module Foodtax
+  class IcPensionIncomeDeduction < Foodtax::ApplicationRecord
+    include FoodtaxHelper
+    self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :seq_no
+    self.table_name = "ic_1232"
+
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
+
+    BANK_SAMPLE = ["304", "305", "306", "307", "308"]
+
+    def self.find_or_initialize_by_declare_user(declare_user, code)
+      ic_pension_income_deduction = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1",
+        C0010: code,
+      )
+      ic_pension_income_deduction
+    end
+
+    def self.create_personal_pension(declare_user)
+      ic_pension_income_deduction = self.find_or_initialize_by_declare_user(declare_user, "21")
+      if ic_pension_income_deduction.new_record?
+        ic_pension_income_deduction.seq_no = "1"
+      else
+        ic_pension_income_deduction.seq_no = Foodtax::IcPensionIncomeDeduction.seq_no_size(declare_user) + 1
+      end
+      bank = Foodtax::IcPensionIncomeBank.unscoped.find_by(bank_cd: BANK_SAMPLE.sample)
+
+      ic_pension_income_deduction.C0020 = bank.bank_cd
+      ic_pension_income_deduction.C0030 = bank.bank_nm
+      ic_pension_income_deduction.acct_cd = "111111111111"
+      ic_pension_income_deduction.C0040 = ""
+      ic_pension_income_deduction.C0050 = declare_user.hometax_individual_income.personal_pension
+      ic_pension_income_deduction.C0060 = declare_user.hometax_individual_income.personal_pension
+      ic_pension_income_deduction.C0070 = 0.0
+      ic_pension_income_deduction.C0080 = declare_user.hometax_individual_income.personal_pension_deduction
+      ic_pension_income_deduction.trade_nm = ""
+      ic_pension_income_deduction.biz_reg_no = ""
+      ic_pension_income_deduction.save!
+    end
+
+    def self.create_pension_retirement(declare_user)
+      ic_pension_income_deduction = self.find_or_initialize_by_declare_user(declare_user, "11")
+      if ic_pension_income_deduction.new_record?
+        ic_pension_income_deduction.seq_no = "1"
+      else
+        ic_pension_income_deduction.seq_no = Foodtax::IcPensionIncomeDeduction.seq_no_size(declare_user) + 1
+      end
+      bank = Foodtax::IcPensionIncomeBank.unscoped.find_by(bank_cd: BANK_SAMPLE.sample)
+
+      ic_pension_income_deduction.C0020 = bank.bank_cd
+      ic_pension_income_deduction.C0030 = bank.bank_nm
+      ic_pension_income_deduction.acct_cd = "111111111111"
+      ic_pension_income_deduction.C0040 = ""
+      ic_pension_income_deduction.C0050 = declare_user.hometax_individual_income.retirement_pension_tax_credit
+      ic_pension_income_deduction.C0060 = declare_user.hometax_individual_income.retirement_pension_tax_credit
+      ic_pension_income_deduction.C0070 = declare_user.pension_tax_rate
+      ic_pension_income_deduction.C0080 = declare_user.retirement_pension_tax_credit_amount
+      ic_pension_income_deduction.trade_nm = ""
+      ic_pension_income_deduction.biz_reg_no = ""
+      ic_pension_income_deduction.save!
+    end
+
+    def self.create_pension_account(declare_user)
+      ic_pension_income_deduction = self.find_or_initialize_by_declare_user(declare_user, "22")
+      if ic_pension_income_deduction.new_record?
+        ic_pension_income_deduction.seq_no = "1"
+      else
+        ic_pension_income_deduction.seq_no = Foodtax::IcPensionIncomeDeduction.seq_no_size(declare_user) + 1
+      end
+      bank = Foodtax::IcPensionIncomeBank.unscoped.find_by(bank_cd: BANK_SAMPLE.sample)
+
+      ic_pension_income_deduction.C0020 = bank.bank_cd
+      ic_pension_income_deduction.C0030 = bank.bank_nm
+      ic_pension_income_deduction.acct_cd = "111111111111"
+      ic_pension_income_deduction.C0040 = ""
+      ic_pension_income_deduction.C0050 = declare_user.hometax_individual_income.pension_account_tax_credit
+      ic_pension_income_deduction.C0060 = declare_user.hometax_individual_income.pension_account_tax_credit
+      ic_pension_income_deduction.C0070 = declare_user.pension_tax_rate
+      ic_pension_income_deduction.C0080 = declare_user.pension_account_tax_credit_amount
+      ic_pension_income_deduction.trade_nm = ""
+      ic_pension_income_deduction.biz_reg_no = ""
+      ic_pension_income_deduction.save!
+    end
+
+    def self.seq_no_size(declare_user)
+      Foodtax::IcPensionIncomeDeduction.where(
+          cmpy_cd: "00025",
+          person_cd: declare_user.person_cd,
+          term_cd: "2019",
+          declare_seq: "1",
+        ).length
+    end
+  end
+end

--- a/app/models/foodtax/ic_pension_income_deduction.rb
+++ b/app/models/foodtax/ic_pension_income_deduction.rb
@@ -19,6 +19,12 @@ module Foodtax
       ic_pension_income_deduction
     end
 
+    def self.import(declare_user)
+      self.create_personal_pension(declare_user) if declare_user.hometax_individual_income.personal_pension
+      self.create_pension_retirement(declare_user) if declare_user.hometax_individual_income.retirement_pension_tax_credit
+      self.create_pension_account(declare_user) if declare_user.hometax_individual_income.pension_account_tax_credit
+    end
+
     def self.create_personal_pension(declare_user)
       ic_pension_income_deduction = self.find_or_initialize_by_declare_user(declare_user, "21")
       if ic_pension_income_deduction.new_record?

--- a/app/models/foodtax/ic_person.rb
+++ b/app/models/foodtax/ic_person.rb
@@ -1,16 +1,20 @@
 module Foodtax
   class IcPerson < Foodtax::ApplicationRecord
     include FoodtaxHelper
-    self.primary_keys = :member_cd, :cmpy_cd, :term_cd, :declare_seq
-    self.table_name = "VA_ELEC_FILE_CONTENTS"
+    self.primary_keys = :cmpy_cd, :person_cd
     after_initialize :default_user_id
 
-    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
-
-    private
-
-    def default_user_id
+    def initialize_by_declare_user(declare_user, member_cd)
+      self.cmpy_cd = "00025"
+      self.person_cd = "P#{"%06d" % declare_user.id}"
+      self.jumin_no = declare_user.residence_number
+      self.name = declare_user.name
+      self.member_cd = member_cd
+      address = declare_user.hometax_address || declare_user.address
+      split_address = address.split
+      self.addr1 = split_address[0]
+      self.addr2 = split_address[1]
+      self.tel_no = declare_user.phone_number
     end
   end
 end

--- a/app/models/foodtax/ic_person.rb
+++ b/app/models/foodtax/ic_person.rb
@@ -4,17 +4,22 @@ module Foodtax
     self.primary_keys = :cmpy_cd, :person_cd
     after_initialize :default_user_id
 
-    def initialize_by_declare_user(declare_user, member_cd)
-      self.cmpy_cd = "00025"
-      self.person_cd = "P#{"%06d" % declare_user.id}"
-      self.jumin_no = declare_user.residence_number
-      self.name = declare_user.name
-      self.member_cd = member_cd
+    has_many :ic_families, class_name: "IcFamily", foreign_key: [:cmpy_cd, :person_cd]
+
+    def self.find_or_initialize_by_declare_user(declare_user, member_cd)
+      ic_person = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        member_cd: member_cd
+      )
+      ic_person.jumin_no = declare_user.residence_number
+      ic_person.name = declare_user.name
       address = declare_user.hometax_address || declare_user.address
       split_address = address.split
-      self.addr1 = split_address[0]
-      self.addr2 = split_address[1]
-      self.tel_no = declare_user.phone_number
+      ic_person.addr1 = split_address[0]
+      ic_person.addr2 = split_address[1]
+      ic_person.tel_no = declare_user.user.phone_number
+      ic_person
     end
   end
 end

--- a/app/models/foodtax/ic_person.rb
+++ b/app/models/foodtax/ic_person.rb
@@ -6,11 +6,11 @@ module Foodtax
 
     has_many :ic_families, class_name: "IcFamily", foreign_key: [:cmpy_cd, :person_cd]
 
-    def self.find_or_initialize_by_declare_user(declare_user, member_cd)
+    def self.find_or_initialize_by_declare_user(declare_user)
       ic_person = self.find_or_initialize_by(
         cmpy_cd: "00025",
         person_cd: declare_user.person_cd,
-        member_cd: member_cd
+        member_cd: declare_user.member_cd,
       )
       ic_person.jumin_no = declare_user.residence_number
       ic_person.name = declare_user.name

--- a/app/models/foodtax/ic_prepaid_tax.rb
+++ b/app/models/foodtax/ic_prepaid_tax.rb
@@ -4,6 +4,8 @@ module Foodtax
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq
     self.table_name = "ic_1100"
 
+    after_initialize :initialize_rural_taxes
+
     belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
 
     def self.find_or_initialize_by_declare_user(declare_user)
@@ -37,10 +39,10 @@ module Foodtax
     private
 
     def initialize_rural_taxes
-      prepaid_tax.C0120 = 0
-      prepaid_tax.C0130 = 0
-      prepaid_tax.C0140 = 0
-      prepaid_tax.C0150 = 0
+      self.C0120 = 0
+      self.C0130 = 0
+      self.C0140 = 0
+      self.C0150 = 0
     end
   end
 end

--- a/app/models/foodtax/ic_prepaid_tax.rb
+++ b/app/models/foodtax/ic_prepaid_tax.rb
@@ -4,7 +4,43 @@ module Foodtax
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq
     self.table_name = "ic_1100"
 
-    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
+
+    def self.find_or_initialize_by_declare_user(declare_user)
+      ic_prepaid_tax = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1"
+      )
+    end
+
+    def self.import_prepaid_tax(declare_user)
+      prepaid_tax = self.find_or_initialize_by_declare_user(
+        declare_user
+      )
+      return if declare_user.prepaid_tax_sum <= 0
+      prepaid_tax.C0010 = declare_user.prepaid_tax_sum
+      prepaid_tax.C0020 = 0
+      prepaid_tax.C0030 = 0
+      prepaid_tax.C0040 = 0
+      prepaid_tax.C0050 = 0
+      prepaid_tax.C0060 = 0
+      prepaid_tax.C0070 = 0
+      prepaid_tax.C0080 = 0
+      prepaid_tax.C0090 = 0
+      prepaid_tax.C0100 = 0
+      prepaid_tax.C0110 = declare_user.prepaid_tax_sum
+      prepaid_tax.save!
+    end
+
+    private
+
+    def initialize_rural_taxes
+      prepaid_tax.C0120 = 0
+      prepaid_tax.C0130 = 0
+      prepaid_tax.C0140 = 0
+      prepaid_tax.C0150 = 0
+    end
   end
 end

--- a/app/models/foodtax/ic_simplerate.rb
+++ b/app/models/foodtax/ic_simplerate.rb
@@ -1,16 +1,35 @@
 module Foodtax
   class IcSimplerate < Foodtax::ApplicationRecord
     include FoodtaxHelper
-    self.primary_keys = :member_cd, :cmpy_cd, :term_cd, :declare_seq
-    self.table_name = "VA_ELEC_FILE_CONTENTS"
-    after_initialize :default_user_id
+    self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :income_seq_no
+
+    self.table_name = "ic_simplerate"
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
 
-    private
+    def self.find_or_initialize_by_declare_user(declare_user, cm_member)
+      ic_simplerate = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "#{1.year.ago.year}"
+        declare_seq: "1"
+        income_seq_no: "1"
+      )
 
-    def default_user_id
-    end
+      ic_simplerate.income_seq_no = "1"
+      ic_simplerate.income_type = "40"
+      ic_simplerate.biz_reg_no = cm_member.biz_reg_no
+      ic_simplerate.addr = declare_user.hometax_address || declare_user.address
+      ic_simplerate.upjong_cd = cm_member.upjong_cd
+      ic_simplerate.upjong_nm = cm_member.jongmok
+      ic_simplerate.jata_type = "T"
+
+      ic_simplerate.jaga_rate = declare_user.base_ratio_self
+      ic_simplerate.taga_rate = declare_user.base_ratio_basic
+
+      ic_simplerate.sale_amt = declare_user.business_income_sum
+      ic_simplerate.cost_amt = declare_user.expenses_sum_by_ratio
+      ic_simplerate.income_amt = declare_user.total_income_amount
+      ic_simplerate
   end
 end

--- a/app/models/foodtax/ic_simplerate.rb
+++ b/app/models/foodtax/ic_simplerate.rb
@@ -11,8 +11,8 @@ module Foodtax
       ic_simplerate = self.find_or_initialize_by(
         cmpy_cd: "00025",
         person_cd: declare_user.person_cd,
-        term_cd: "#{1.year.ago.year}"
-        declare_seq: "1"
+        term_cd: "#{1.year.ago.year}",
+        declare_seq: "1",
         income_seq_no: "1"
       )
 
@@ -31,5 +31,6 @@ module Foodtax
       ic_simplerate.cost_amt = declare_user.expenses_sum_by_ratio
       ic_simplerate.income_amt = declare_user.total_income_amount
       ic_simplerate
+    end
   end
 end

--- a/app/models/foodtax/ic_simplerate.rb
+++ b/app/models/foodtax/ic_simplerate.rb
@@ -5,7 +5,7 @@ module Foodtax
 
     self.table_name = "ic_simplerate"
 
-    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
 
     def self.find_or_initialize_by_declare_user(declare_user, cm_member)
       ic_simplerate = self.find_or_initialize_by(
@@ -24,11 +24,11 @@ module Foodtax
       ic_simplerate.upjong_nm = cm_member.jongmok
       ic_simplerate.jata_type = "T"
 
-      ic_simplerate.jaga_rate = declare_user.base_ratio_self
-      ic_simplerate.taga_rate = declare_user.base_ratio_basic
+      ic_simplerate.jaga_rate = declare_user.hometax_individual_income.base_ratio_self
+      ic_simplerate.taga_rate = declare_user.hometax_individual_income.base_ratio_basic
 
-      ic_simplerate.sale_amt = declare_user.business_income_sum
-      ic_simplerate.cost_amt = declare_user.expenses_sum_by_ratio
+      ic_simplerate.sale_amt = declare_user.business_incomes_sum
+      ic_simplerate.cost_amt = declare_user.hometax_individual_income.expenses_sum_by_ratio
       ic_simplerate.income_amt = declare_user.total_income_amount
       ic_simplerate
     end

--- a/app/models/foodtax/ic_simplified_bookkeeping.rb
+++ b/app/models/foodtax/ic_simplified_bookkeeping.rb
@@ -4,7 +4,69 @@ module Foodtax
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :seq_no
     self.table_name = "ic_1130"
 
-    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
+
+    def self.find_or_initialize_by_declare_user(declare_user)
+      ic_pension_income_deduction = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1"
+      )
+      ic_pension_income_deduction
+    end
+
+    def self.import(declare_user, cm_member, ic_person, merged_bookkeepings)
+      bookkeeping = self.find_or_initialize_by_declare_user(declare_user)
+      bookkeeping.seq_no = "1"
+      bookkeeping.member_cd = cm_member.member_cd
+
+      bookkeeping.income_type = "40"
+      bookkeeping.biz_reg_no = cm_member.biz_reg_no
+      bookkeeping.addr = declare_user.hometax_address || declare_user.address
+      bookkeeping.trade_nm = cm_member.trade_nm
+      bookkeeping.upjong_cd = cm_member.upjong_cd
+      bookkeeping.upjong_nm = cm_member.jongmok
+
+      bookkeeping.book_sale_amt = declare_user.business_incomes_sum
+      bookkeeping.book_etc_sale_amt = 0
+      bookkeeping.book_sale_sum_amt = declare_user.business_incomes_sum
+      bookkeeping.sale_except_amt = 0
+      bookkeeping.sale_append_amt = 0
+      bookkeeping.total_sale_amt = declare_user.business_incomes_sum
+
+      bookkeeping.salecost_init = 0
+      bookkeeping.salecost_purchase = merged_bookkeepings.sales_costs
+      bookkeeping.salecost_stock = 0
+      bookkeeping.salecost_amt = merged_bookkeepings.sales_costs
+
+      bookkeeping.normal_salary = merged_bookkeepings.wages
+      bookkeeping.normal_utilitybill = merged_bookkeepings.public_imposts
+      bookkeeping.normal_rent = merged_bookkeepings.rentals
+      bookkeeping.normal_interest = merged_bookkeepings.interests
+      bookkeeping.normal_entertain = merged_bookkeepings.entertainments
+      bookkeeping.normal_donate =  merged_bookkeepings.donations
+      bookkeeping.normal_depre =  merged_bookkeepings.depreciations
+      bookkeeping.normal_carmgmt = merged_bookkeepings.vehicle_maintenances
+      bookkeeping.normal_commission = merged_bookkeepings.commissions
+      bookkeeping.normal_consumable = merged_bookkeepings.supplies
+      bookkeeping.normal_walfare = merged_bookkeepings.welfares
+      bookkeeping.normal_transport = merged_bookkeepings.transportations
+      bookkeeping.normal_advertise = merged_bookkeepings.advertisements
+      bookkeeping.normal_traffic = merged_bookkeepings.travel_expenses
+      bookkeeping.normal_etc = merged_bookkeepings.etcs
+      bookkeeping.normal_sum = merged_bookkeepings.total_amount - merged_bookkeepings.sales_costs
+      bookkeeping.book_cost_sum_amt = merged_bookkeepings.total_amount
+      
+      bookkeeping.cost_except_amt = 0
+      bookkeeping.cost_append_amt = 0
+      bookkeeping.total_cost_amt = merged_bookkeepings.total_amount
+      bookkeeping.plusminus_income_amt = declare_user.total_income_amount
+      bookkeeping.donate_limit_excess = 0
+      bookkeeping.donate_cost_append = 0
+
+      bookkeeping.year_income_amt = declare_user.total_income_amount
+      bookkeeping.save!
+    end
   end
 end

--- a/app/models/foodtax/ic_special_taxation_income_deduction.rb
+++ b/app/models/foodtax/ic_special_taxation_income_deduction.rb
@@ -17,27 +17,31 @@ module Foodtax
     end
 
     def self.import_deductions(declare_user)
-      personal_deduction = self.find_or_initialize_by_declare_user(
-        declare_user,
-        "105"
-      )
-      personal_deduction.create_deduction(
-        0,
-        declare_user.hometax_individual_income.personal_pension_deduction,
-        ""
-      )
-      personal_deduction.save!
+      if hometax_individual_income.personal_pension_deduction > 0
+        personal_deduction = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "105"
+        )
+        personal_deduction.create_deduction(
+          0,
+          declare_user.hometax_individual_income.personal_pension_deduction,
+          ""
+        )
+        personal_deduction.save!
+      end
 
-      merchant_deduction = self.find_or_initialize_by_declare_user(
-        declare_user,
-        "115"
-      )
-      merchant_deduction.create_deduction(
-        declare_user.hometax_individual_income.merchant_pension,
-        declare_user.hometax_individual_income.merchant_pension_deduction,
-        declare_user.businesses.first.registration_number
-      )
-      merchant_deduction.save!
+      if declare_user.hometax_individual_income.merchant_pension > 0
+        merchant_deduction = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "115"
+        )
+        merchant_deduction.create_deduction(
+          declare_user.hometax_individual_income.merchant_pension,
+          declare_user.hometax_individual_income.merchant_pension_deduction,
+          declare_user.businesses.first.registration_number
+        )
+        merchant_deduction.save!
+      end
     end
 
     def create_deduction(origin_amount, limited_amount, registration_number)

--- a/app/models/foodtax/ic_special_taxation_income_deduction.rb
+++ b/app/models/foodtax/ic_special_taxation_income_deduction.rb
@@ -4,7 +4,47 @@ module Foodtax
     self.primary_keys = :cmpy_cd, :person_cd, :term_cd, :declare_seq, :deduct_cd
     self.table_name = "ic_1061"
 
-    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
+
+    def self.find_or_initialize_by_declare_user(declare_user, deduct_cd)
+      deduction = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1",
+        deduct_cd: deduct_cd,
+      )
+    end
+
+    def self.import_deductions(declare_user)
+      personal_deduction = self.find_or_initialize_by_declare_user(
+        declare_user,
+        "105"
+      )
+      personal_deduction.create_deduction(
+        0,
+        declare_user.hometax_individual_income.personal_pension_deduction,
+        ""
+      )
+      personal_deduction.save!
+
+      merchant_deduction = self.find_or_initialize_by_declare_user(
+        declare_user,
+        "115"
+      )
+      merchant_deduction.create_deduction(
+        declare_user.hometax_individual_income.merchant_pension,
+        declare_user.hometax_individual_income.merchant_pension_deduction,
+        declare_user.businesses.first.registration_number
+      )
+      merchant_deduction.save!
+    end
+
+    def create_deduction(origin_amount, limited_amount, registration_number)
+      self.gonggam_type = ""
+      self.target_amt = origin_amount
+      self.deduct_amt = limited_amount
+      self.biz_reg_no = ""
+    end
   end
 end

--- a/app/models/foodtax/ic_tax_credit_exemption.rb
+++ b/app/models/foodtax/ic_tax_credit_exemption.rb
@@ -6,11 +6,92 @@ module Foodtax
     after_initialize :default_user_id
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
+    belongs_to :ic_person, foreign_key: :person_cd, primary_key: :person_cd
 
-    private
+    def self.find_or_initialize_by_declare_user(declare_user, code)
+      ic_tax_credit_exemption = self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        person_cd: declare_user.person_cd,
+        term_cd: "2019",
+        declare_seq: "1",
+        c0010: code,
+      )
+      ic_tax_credit_exemption
+    end
 
-    def default_user_id
+    def self.import_credit_exemption
+      if declare_user.base_tax_credit_amount > 0
+        base_tax_credit = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "284"
+        )
+        base_tax_credit.create_credit_exemption(0, 70000)
+      end
+
+      if declare_user.children_tax_credit_amount > 0
+        children_tax_credit = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "273"
+        )
+        children_tax_credit.create_credit_exemption(
+          declare_user.deductible_children_size,
+          declare_user.children_tax_credit_amount
+        )
+      end
+
+      if declare_user.newborn_baby_tax_credit_amount > 0
+        new_born_tax_credit = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "290"
+        )
+        new_born_tax_credit(
+          declare_user.new_born_children_or_adopted_count,
+          declare_user.newborn_baby_tax_credit_amount
+        )
+      end
+
+      if declare_user.calculated_tax.online_declare_credit_amount > 0
+        online_declare_tax_credit = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "244"
+        )
+        online_declare_tax_credit.create_credit_exemption(
+          0,
+          declare_user.calculated_tax.online_declare_credit_amount
+        )
+      end
+
+      if declare_user.retirement_pension_tax_credit_amount > 0
+        retirement_pension_tax_credit = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "275"
+        )
+        retirement_pension_tax_credit.create_credit_exemption(
+          declare_user.hometax_individual_income.retirement_pension_tax_credit,
+          declare_user.retirement_pension_tax_credit_amount
+        )
+        Foodtax::IcPensionIncomeDeduction.create_pension_retirement(declare_user)
+      end
+
+      if declare_user.pension_account_tax_credit_amount > 0
+        pension_account_tax_credit = self.find_or_initialize_by_declare_user(
+          declare_user,
+          "276"
+        )
+        pension_account_tax_credit.create_credit_exemption(
+          declare_user.hometax_individual_income.pension_account_tax_credit,
+          declare_user.pension_account_tax_credit_amount,
+        )
+        Foodtax::IcPensionIncomeDeduction.create_pension_account(declare_user)
+      end
+    end
+
+    def create_credit_exemption(source_amount, amount)
+      self.c0020 = source_amount
+      self.c0030 = amount
+      self.biz_reg_no = ""
+      self.income_seq_no = "0"
+      save!
     end
   end
 end

--- a/app/models/foodtax/ic_tax_credit_exemption.rb
+++ b/app/models/foodtax/ic_tax_credit_exemption.rb
@@ -18,7 +18,7 @@ module Foodtax
       ic_tax_credit_exemption
     end
 
-    def self.import_credit_exemption(declare_user)
+    def self.import(declare_user)
       index = 1
       if declare_user.base_tax_credit_amount > 0
         base_tax_credit = self.find_or_initialize_by_declare_user(

--- a/app/models/foodtax/ic_tax_penalty.rb
+++ b/app/models/foodtax/ic_tax_penalty.rb
@@ -5,6 +5,5 @@ module Foodtax
     self.table_name = "ic_1090"
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    belongs_to :va_head, foreign_key: :member_cd, primary_key: :member_cd
   end
 end

--- a/app/models/foodtax/va_head.rb
+++ b/app/models/foodtax/va_head.rb
@@ -12,7 +12,7 @@ module Foodtax
       self.biz_addr1 = business.hometax_business.address.split&.first
       self.biz_addr2 = business.hometax_business.address.split&.second
       self.cp_no = business.hometax_business.phone_number || business.owner.phone_number
-      self.tax_type = foodtax_tax_type(business.hometax_business)
+      self.tax_type = foodtax_tax_type(business.hometax_business.taxation_type)
       self.upjong_cd = business.hometax_business.classification_code if business.hometax_business.classification_code
       self.closure_yn = "Y" if business.closed_at.present?
       self.closure_dt = business.closed_at.strftime("%Y%m%d") if business.closed_at.present?

--- a/app/services/create_income_foodtax.rb
+++ b/app/services/create_income_foodtax.rb
@@ -28,9 +28,6 @@ class CreateIncomeFoodtax < Service::Base
       ic_income_deduction = 
         Foodtax::IcIncomeDeduction.import_deductions(declare_user)
 
-      ic_special_taxation_income_deduction = 
-        Foodtax::IcSpecialTaxationIncomeDeduction.import_deductions(declare_user)
-
       ic_income_details_sum = Foodtax::IcIncomeDetailsSum
         .find_or_initialize_by_declare_user(
           declare_user

--- a/app/services/create_income_foodtax.rb
+++ b/app/services/create_income_foodtax.rb
@@ -1,0 +1,57 @@
+class CreateIncomeFoodtax < Service::Base
+  param :declare_user_id
+  
+  def run
+    declare_user = DeclareUser.find(declare_user_id)    
+    ActiveRecord::Base.transaction do
+      cm_member = Foodtax::CmMember.find_or_initialize_by_declare_user(declare_user)
+      cm_member.save!
+      cm_charge = Foodtax::CmCharge.find_or_initialize_by_declare_user(declare_user)
+      cm_charge.save!
+      ic_person = Foodtax::IcPerson.find_or_initialize_by_declare_user(declare_user)
+      ic_person.save!
+
+      ic_family = Foodtax::IcFamily.import_by_declare_user(declare_user)
+
+      ic_head = Foodtax::IcHead.find_or_initialize_by_declare_user(
+        ic_person,
+        declare_user,
+        declare_user.calculated_tax
+      )
+      ic_head.save!
+      ic_income = Foodtax::IcIncome.find_or_initialize_by_declare_user(
+        declare_user,
+        cm_member
+      )
+      ic_income.save!
+
+      ic_income_deduction = 
+        Foodtax::IcIncomeDeduction.import_deductions(declare_user)
+
+      ic_special_taxation_income_deduction = 
+        Foodtax::IcSpecialTaxationIncomeDeduction.import_deductions(declare_user)
+
+      ic_income_details_sum = Foodtax::IcIncomeDetailsSum
+        .find_or_initialize_by_declare_user(
+          declare_user
+        )
+      ic_income_details_sum.save!
+
+      ic_tax_credit_exemption = Foodtax::IcTaxCreditExemption.import(declare_user)
+
+      ic_pension_income_deduction =
+        Foodtax::IcPensionIncomeDeduction.create_personal_pension(declare_user)
+
+      ic_prepaid_tax = Foodtax::IcPrepaidTax.import_prepaid_tax(
+        declare_user
+      )
+
+      ic_simplified_bookkeeping = Foodtax::IcSimplifiedBookkeeping.import(
+        declare_user,
+        cm_member,
+        ic_person,
+        declare_user.merged_bookkeepings
+      )
+    end
+  end
+end

--- a/app/services/create_income_foodtax.rb
+++ b/app/services/create_income_foodtax.rb
@@ -46,12 +46,22 @@ class CreateIncomeFoodtax < Service::Base
         declare_user
       )
 
-      ic_simplified_bookkeeping = Foodtax::IcSimplifiedBookkeeping.import(
-        declare_user,
-        cm_member,
-        ic_person,
-        declare_user.merged_bookkeepings
-      )
+      if declare_user.apply_bookkeeping?
+        ic_simplified_bookkeeping = Foodtax::IcSimplifiedBookkeeping.import(
+          declare_user,
+          cm_member,
+          ic_person,
+          declare_user.merged_bookkeepings
+        )
+      else
+        if declare_user.hometax_individual_income.is_simple_ratio?
+          ic_simplerate = Foodtax::IcSimplerate.find_or_initialize_by_declare_user(
+            declare_user,
+            cm_member
+          )
+          ic_simplerate.save!
+        end
+      end
     end
   end
 end

--- a/app/services/create_income_foodtax.rb
+++ b/app/services/create_income_foodtax.rb
@@ -11,7 +11,7 @@ class CreateIncomeFoodtax < Service::Base
       ic_person = Foodtax::IcPerson.find_or_initialize_by_declare_user(declare_user)
       ic_person.save!
 
-      ic_family = Foodtax::IcFamily.import_by_declare_user(declare_user)
+      ic_family = Foodtax::IcFamily.import(declare_user)
 
       ic_head = Foodtax::IcHead.find_or_initialize_by_declare_user(
         ic_person,


### PR DESCRIPTION
전자 신고 파일 생성을 위한 간편장부 세액 계산결과를 Foodtax에 저장합니다.
전자신고 서식에 포함되는 내용은 다음과 같습니다.

## 공통 서식
- 종합소득세 과세표준확정신고 HEADER
- 종합소득세 과세표준확정신고 기본사항
- 종합소득세 세액의계산
- 종합소득세 사업소득명세서
- 종합소득세 사업소득에대한원천징수세액내역서
- 종합소득세 종합소득금액및결손금이월결손금공제명세서
- 종합소득세 소득공제명세서
- 종합소득세 조세특례제한법상소득공제
- 종합소득세 인적공제자명세신고내역
- 종합소득세 세액감면명세서
- 종합소득세 세액공제명세서
- 종합소득세 기납부세액명세서
- 종합소득세 연금저축등소득공제명세서
## 간편장부 서식
- 종합소득세 간편장부소득금액계산서
- 종합소득세 총수입금액및필요경비명세서
## 단순경비율 서식

기준경비율 추계신고, 근로소득자, 기부금, 결손 등은 제외한 스펙입니다.
