### PR TITLE
[AT-110] 경비율 기준 예상 세액 계산 & 테이블 추가

### DIFF
--- a/app/libs/individual_income/calculated_tax.rb
+++ b/app/libs/individual_income/calculated_tax.rb
@@ -81,6 +81,10 @@ module IndividualIncome
       [calculated_tax_with_penalty - limited_tax_credit, tax_exemption].min
     end
 
+    def determined_tax
+      [calculated_tax - limited_tax_credit - limited_tax_exemption, 0].max
+    end
+
     def payment_tax
       @payment_tax ||= [(calculated_tax_with_penalty - limited_tax_credit - limited_tax_exemption), 0].max - prepaid_tax
     end
@@ -127,6 +131,7 @@ module IndividualIncome
         penalty_tax: penalty_tax,
         prepaid_tax: prepaid_tax,
         payment_tax: payment_tax,
+        determined_tax: determined_tax,
         payment_local_tax: payment_local_tax,
       }.as_json
     end

--- a/app/models/estimated_calulated_income_tax.rb
+++ b/app/models/estimated_calulated_income_tax.rb
@@ -1,0 +1,2 @@
+class EstimatedCalulatedIncomeTax < ApplicationRecord
+end

--- a/db/migrate/20200520183855_create_estimated_calulated_income_taxes.rb
+++ b/db/migrate/20200520183855_create_estimated_calulated_income_taxes.rb
@@ -1,0 +1,38 @@
+class CreateEstimatedCalulatedIncomeTaxes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :estimated_calulated_income_taxes do |t|
+      t.bigint :owner_id, null: false
+      t.integer :year, null: false
+      t.string :account_type, null: false
+      t.string :base_expense_rate, null: false
+      t.float :base_ratio, null: false
+      t.float :simple_ratio, null: false
+      t.bigint :business_incomes, null: false
+      t.bigint :expenses, null: false
+      t.bigint :total_income, null: false
+      t.integer :income_deduction, null: false
+      t.integer :personal_deduction, null: false
+      t.integer :personal_pension_deduction
+      t.integer :merchant_pension_deduction
+      t.integer :national_pension_deduction
+      t.integer :online_declare_credit_amount
+      t.integer :children_tax_credit_amount
+      t.integer :newborn_baby_tax_credit_amount
+      t.integer :pension_account_tax_credit_amount
+      t.integer :retirement_pension_tax_credit_amount
+      t.integer :base_taxation, null: false
+      t.float :tax_rate, null: false
+      t.integer :calculated_tax, null: false
+      t.integer :tax_exemption, null: false
+      t.integer :tax_credit, null: false
+      t.integer :determined_tax, null: false
+      t.integer :penalty_tax, null: false
+      t.integer :prepaid_tax, null: false
+      t.integer :payment_tax, null: false
+      t.integer :payment_local_tax, null: false
+
+      t.timestamps
+    end
+    add_index :estimated_calulated_income_taxes, [:owner_id, :year], unique: true
+  end
+end

--- a/lib/tasks/app/calculate/estimated_tax.rake
+++ b/lib/tasks/app/calculate/estimated_tax.rake
@@ -1,0 +1,76 @@
+namespace :app do
+  namespace :calculate do
+    namespace :estimated_tax do
+      desc "Estimated tax based on simple ratio"
+      task income_tax: :environment do
+        estimated_calulated_taxes = []
+        hometax_individual_incomes = 
+          HometaxIndividualIncome.where(<<-SQL.squish)
+            account_type = '간편장부대상자'
+            AND base_expense_rate = '단순경비율'
+            AND declare_year = '201901' 
+            AND interest_income IS FALSE 
+            AND dividend_income IS FALSE 
+            AND wage_single_income IS FALSE 
+            AND wage_multiple_income IS FALSE 
+            AND pension_income IS FALSE 
+            AND other_income IS FALSE 
+            AND religions_income IS FALSE 
+            AND yearend_settlement_income IS FALSE 
+            AND unfaithful_report_invoice_amount = 0 
+            AND not_register_cash_receipts = '' 
+            AND not_issued_cash_receipts_amount = 0 
+            AND decline_cards_amount = 0
+            AND decline_cards_count = 0
+            AND decline_cash_receipts_amount = 0
+            AND decline_cash_receipts_count = 0
+            AND unfaithful_business_report_amount = 0
+            AND no_business_account_penalty = ''
+            AND id IN (
+              SELECT hometax_individual_income_id
+              FROM hometax_business_incomes
+              WHERE hometax_individual_income_id NOT IN 
+                (
+                  SELECT DISTINCT(hometax_individual_income_id)
+                    FROM hometax_business_incomes
+                    WHERE (
+                        hometax_business_incomes.classficaition_code IN ('701101', '701102', '701103' ,'701104', '701301')
+                      )
+                      OR (business_type = '공동') 
+                      OR (registration_number = '') 
+                    GROUP BY hometax_business_incomes.hometax_individual_income_id
+                    HAVING COUNT(DISTINCT(registration_number)) = 1
+                )
+            )
+          SQL
+        hometax_individual_incomes.each do |h|
+          calculated_tax_by_ratio = IndividualIncome::CalculatedTax.new(
+            business_incomes: h.business_income_sum,
+            expenses: h.expenses_sum_by_ratio,
+            income_deduction: 1500000,
+            tax_exemption: 0,
+            tax_credit: 90000,
+            penalty_tax: 0,
+            prepaid_tax: 0,
+          )
+          e = EstimatedCalulatedIncomeTax.new(
+            calculated_tax_by_ratio.as_json.merge({
+              account_type: h.account_type,
+              base_expense_rate: h.base_expense_rate,
+              base_ratio: h.base_ratio_basic,
+              simple_ratio: h.simple_ratio_basic,
+              owner_id: h.owner_id,
+              year: 2019,
+              income_deduction: 1500000,
+              personal_deduction: 1500000,
+              online_declare_credit_amount: 20000,
+            })
+            
+          )
+          estimated_calulated_taxes << e
+        end
+        EstimatedCalulatedIncomeTax.import!(estimated_calulated_taxes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
경비율 기준으로 예상 세액을 산출 할 수 있는 로직을 테이블에 추가한다.
기본 본인공제와 표준/전자신고 세액공제를 기본으로 추가하고 단순/기준 경비율로 계산된 결과를 반영한다.