### PR TITLE
납부세액 status 저장 테이블 생성

### DIFF
--- a/app/jobs/calculate_income_tax_job.rb
+++ b/app/jobs/calculate_income_tax_job.rb
@@ -1,0 +1,29 @@
+class CalculateIncomeTaxJob < ApplicationJob
+  queue_as :calculate_income_tax
+
+  def perform(declare_user_id)
+    d = DeclareUser.find(declare_user_id)
+    defaults = {
+        declare_user_id: declare_user_id,
+        declare_type: d.apply_bookkeeping? ? "간편장부" : d.hometax_individual_income.base_expense_rate,
+        account_type: d.hometax_individual_income.account_type,
+        base_expense_rate: d.hometax_individual_income.base_expense_rate,
+        base_ratio: d.hometax_individual_income.base_ratio_basic,
+        simple_ratio: d.hometax_individual_income.simple_ratio_basic,
+        owner_id: d.hometax_individual_income.owner_id,
+      }
+    calculated_income_tax = defaults.merge(d.calculated_tax.as_json)
+    calculated_income_tax.merge!({
+      personal_deduction: d.deductible_persons_sum || 0,
+      pension_deduction: d.pensions_sum || 0,
+      children_tax_credit_amount: d.children_tax_credit_amount || 0,
+      newborn_baby_tax_credit_amount: d.newborn_baby_tax_credit_amount || 0,
+      pension_account_tax_credit_amount: d.pension_account_tax_credit_amount || 0,
+      retirement_pension_tax_credit_amount: d.retirement_pension_tax_credit_amount || 0
+    })
+
+    c = CalculatedIncomeTax.find_or_initialize_by(declare_user_id: d.id)
+    c.assign_attributes(calculated_income_tax)
+    c.save!
+  end
+end

--- a/app/jobs/calculate_income_tax_job.rb
+++ b/app/jobs/calculate_income_tax_job.rb
@@ -3,6 +3,7 @@ class CalculateIncomeTaxJob < ApplicationJob
 
   def perform(declare_user_id)
     d = DeclareUser.find(declare_user_id)
+    raise "#{d.inspect} does not have hometax_individual_income" if d.hometax_individual_income.nil?
     defaults = {
         declare_user_id: declare_user_id,
         declare_type: d.apply_bookkeeping? ? "간편장부" : d.hometax_individual_income.base_expense_rate,
@@ -21,7 +22,6 @@ class CalculateIncomeTaxJob < ApplicationJob
       pension_account_tax_credit_amount: d.pension_account_tax_credit_amount || 0,
       retirement_pension_tax_credit_amount: d.retirement_pension_tax_credit_amount || 0
     })
-
     c = CalculatedIncomeTax.find_or_initialize_by(declare_user_id: d.id)
     c.assign_attributes(calculated_income_tax)
     c.save!

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module Tanager
 
     config.time_zone = "Seoul"
     config.active_record.default_timezone = :local
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,8 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  config.active_job.queue_adapter     = :sidekiq
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,10 +1,18 @@
-redis_options = { url: "redis://#{ENV["REDIS_HOST"]}:#{ENV["REDIS_PORT"]}/1" }
+if ENV["REDIS_HOST"]
+  redis_options = { url: "redis://#{ENV["REDIS_HOST"]}:#{ENV["REDIS_PORT"]}/1" }
+else
+  redis_options = { url: "redis://127.0.0.1:6379/1" }
+end
 
 if Rails.env.test?
   redis_options[:driver] = Redis::Connection::Memory if defined?(Redis::Connection::Memory)
 end
 
 Sidekiq.configure_server do |config|
+  config.redis = redis_options
+end
+
+Sidekiq.configure_client do |config|
   config.redis = redis_options
 end
 Sidekiq::Extensions.enable_delay!

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,6 @@
 :concurrency: 30
 :queues:
   - default
+  - [send_slack_message, 2]
+  - calculate_income_tax
+  - estimate_income_tax

--- a/db/migrate/20200523131557_create_calculated_income_taxes.rb
+++ b/db/migrate/20200523131557_create_calculated_income_taxes.rb
@@ -1,0 +1,34 @@
+class CreateCalculatedIncomeTaxes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :calculated_income_taxes do |t|
+      t.references :declare_user, null: false, foreign_key: true, unique: true
+      t.string :declare_type, null: false
+      t.string :account_type, null: false
+      t.string :base_expense_rate, null: false
+      t.float :base_ratio, null: false
+      t.float :simple_ratio, null: false
+      t.bigint :business_incomes, null: false
+      t.bigint :expenses, null: false
+      t.bigint :total_income, null: false
+      t.integer :income_deduction, null: false
+      t.integer :personal_deduction, null: false
+      t.integer :pension_deduction, null: false
+      t.integer :base_taxation, null: false
+      t.float :tax_rate, null: false
+      t.integer :calculated_tax, null: false
+      t.integer :tax_exemption, null: false
+      t.integer :tax_credit, null: false
+      t.integer :children_tax_credit_amount
+      t.integer :newborn_baby_tax_credit_amount
+      t.integer :pension_account_tax_credit_amount
+      t.integer :retirement_pension_tax_credit_amount
+      t.integer :determined_tax, null: false
+      t.integer :penalty_tax, null: false
+      t.integer :prepaid_tax, null: false
+      t.integer :payment_tax, null: false
+      t.integer :payment_local_tax, null: false
+      t.integer :owner_id, null: false
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
결제 요청 전 납부 세액을 foodtax에 저장하기 전에 tanager에도 저장하는 테이블 생성.
간편장부 / 경비율 기반으로 계산하고 작은 금액을 선택해 사업자의 유리한 금액을 저장한다.
저장되는 내용에는 납부세액을 포함한 공제내역, 수입금액, 경비, 소득금액 등을 저장한다.
