### PR TITLE
전자파일 백그라운드 생성 & API 호출

### DIFF
--- a/app/controllers/declare_users_controller.rb
+++ b/app/controllers/declare_users_controller.rb
@@ -87,11 +87,16 @@ class DeclareUsersController < ApplicationController
     )
     if @declare_user.status.eql?("payment")
       CalculateIncomeTaxJob.perform_later(@declare_user.id)
-      UploadElectronicFile.call(owner_id: @declare_user.user.owner_id, year: 2019, file_string: "test")
+      UploadElectronicFile.call(
+        owner_id: @declare_user.user.owner_id,
+        year: 2019,
+        file_string: "test"
+      )
       SendSlackMessageJob.perform_later(
         "✅납부세액 : #{@declare_user.name} #{@declare_user.calculated_tax.payment_tax}",
         "#tax-ops"
       )
+      CreateElectronicFileJob.perform_later(@declare_user.id)
     end
   end
 end

--- a/app/jobs/create_electronic_file_job.rb
+++ b/app/jobs/create_electronic_file_job.rb
@@ -1,0 +1,27 @@
+class CreateElectronicFileJob < ApplicationJob
+  queue_as :default
+
+  def perform(declare_user_id)
+    declare_user = DeclareUser.find(declare_user_id)
+    year = 1.year.ago.year
+    CreateIncomeFoodtax.call(declare_user_id)
+    ic_head = Foodtax::IcHead.find_or_initialize_by(
+      cmpy_cd: "00025",
+      person_cd: declare_user.person_cd,
+      term_cd: "#{year}",
+      declare_seq: "1",
+      declare_type: "01"
+    )
+    if ic_head.present?
+      declare_file_base64 = ic_head.declare_file
+      UploadElectronicFile.call(
+        owner_id: declare_user.user.owner_id,
+        year: year,
+        file_string: declare_file_base64
+      )
+    else
+      SlackBot.ping("⚠️*전자파일오류* 푸드택스 파일 생성 오류", channel: "#tax-ops")
+      raise "#{declare_user.inspect} is not able to create elec file"
+    end
+  end
+end

--- a/app/models/foodtax/cm_member.rb
+++ b/app/models/foodtax/cm_member.rb
@@ -31,7 +31,12 @@ module Foodtax
       cm_member.tax_type = FoodtaxHelper.foodtax_tax_type(business.taxation_type)
       cm_member.corp_yn = (business.taxation_type == "법인사업자") ? "Y" : "N"
       cm_member.biz_reg_no = business.registration_number
-      cm_member.trade_nm = business.name
+      begin
+        business.name.encode("EUC-KR")
+        cm_member.trade_nm = business.name
+      rescue Encoding::UndefinedConversionError => e
+        cm_member.trade_nm = declare_user.name
+      end
       cm_member.boss_nm = declare_user.name
       cm_member.open_dt = business.opened_at&.strftime("%Y%m%d") || Date.today.last_year.strftime("%Y%m%d")
       cm_member.closure_dt = business.closed_at || ""

--- a/app/services/upload_electronic_file.rb
+++ b/app/services/upload_electronic_file.rb
@@ -24,7 +24,7 @@ class UploadElectronicFile < Service::Base
     if results.dig("result", "message").present?
       Rails.logger.info("error_message : #{results.dig("result", "message")}")
       SendSlackMessageJob.perform_later(
-        "⚠️⚠️⚠️*세금신고오류* owner_id: #{owner_id}, #{results.dig("result", "message")}",
+        "⚠️⚠️⚠️*파일업로드 오류* owner_id: #{owner_id}, #{results.dig("result", "message")}",
         "#tax-ops"
       )
       return nil


### PR DESCRIPTION
전자파일을 백그라운드에서 생성하고 결과를 API에 올리는 작업을 수행합니다.
1. 유저의 납부세액 계산결과를 테이블에 저장
2. 전자파일을 더미(test) 로 생성하여 업로드
3. 전자파일 생성을 위해 background에서 foodtax 디비에 데이터를 추가.
4. 데이터 추가 이후 procedure로 전자파일 base64 문자열 생성
5. snowdon `uploadIndividualIncomeTaxReturnElectronicFile` 를 통해 실제 파일 전달.

실제 파일 전달 이전에는 국세청에 업로드 하지 않습니다.
