### PR TITLE
일반과세자 부가세 HEADER 및 신고서 생성

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,7 @@ class ApplicationController < ActionController::API
   def authorize_cashnote_request
     if request.headers["X-Tanager-Api-Key"] == Rails.application.credentials[Rails.env.to_sym].dig(:client_api_key, :cashnote)
       @owner_id = params[:owner_id]
+      @vat_return_id = params[:vat_return_id]
     else
       render json: { errors: "unauthorized" }, status: :unauthorized
     end

--- a/app/controllers/vat_returns_controller.rb
+++ b/app/controllers/vat_returns_controller.rb
@@ -1,0 +1,7 @@
+class VatReturnsController < ApplicationController
+  before_action :authorize_cashnote_request
+
+  def create
+    electronic_file = CreateVatElecFile.call(@vat_return_id)
+  end
+end

--- a/app/libs/cashnote/graphql_request.rb
+++ b/app/libs/cashnote/graphql_request.rb
@@ -1,8 +1,18 @@
 module Cashnote
   class GraphqlRequest
-    def self.http_query(token, query)
+    def self.http_query(query, token=nil)
+      header = {
+        "X-Bluebird-Api-Key": Rails.application.credentials[Rails.env.to_sym].dig(:snowdon_api, :key),
+        "Content-Type": "application/json",
+      } if token.nil?
+      header ||= { "Authorization": "Bearer #{token}", "Content-Type": "application/json" }      
+      http_request(header, query)
+    end
+
+    private
+
+    def http_request(header, query)
       uri = URI.parse(Rails.env.development? ? "https://staging-api.cashnote.kr/graphql" : "https://api.cashnote.kr/graphql")
-      header = { "Authorization": "Bearer #{token}", "Content-Type": "application/json" }
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       request = Net::HTTP::Post.new(uri.request_uri, header)

--- a/app/libs/vat/mapping_columns.yml
+++ b/app/libs/vat/mapping_columns.yml
@@ -1,0 +1,323 @@
+
+va_head:
+  "1":
+    price: o_s010
+    vat: o_v010
+    desc: 과세매출_세금계산서_금액/세액
+  "2":
+    price: o_s020
+    vat: o_v020
+    desc: 과세매출_매입자_금액/세액
+  "3":
+    price: o_s030
+    vat: o_v030
+    desc: 과세매출_신용카드등_금액/세액
+  "4":
+    price: o_s040
+    vat: o_v040
+    desc: 과세매출_기타_금액/세액
+  "5":
+    price: o_s050
+    desc: 영세매출_세금계산서금액
+  "6":
+    price: o_s060
+    desc: 영세매출_기타_금액
+  "7":
+    price: o_s070
+    vat: o_v070
+    desc: 매출_예정신고누락_세액
+  "8":
+    vat: o_v080
+    desc: 매출_대손세액가감_세액
+  "9":
+    price: o_s090
+    vat: o_v090
+    desc: 매출_합계_금액(과세표준금액)/세액(산출세액)
+  "10":
+    price: i_s010
+    vat: i_v010
+    desc: 과세매입_세금계산서_일반_금액/세액
+  "11":
+    price: i_s020
+    vat: i_v020
+    desc: 과세매입_세금계산서_고정_금액/세액
+  "12":
+    price: i_s030
+    vat: i_v030
+    desc: 과세매입_예정신고누락_금액/세액
+  "13":
+    price: i_s040
+    vat: i_v040
+    desc: 과세매입_매입자_금액/세액
+  "14":
+    price: i_s050
+    vat: i_v050
+    desc: 과세매입_기타공제_금액/세액
+  "15":
+    price: i_s060
+    vat: i_v060
+    desc: 과세매입_합계_금액/세액
+  "16":
+    price: i_s070
+    vat: i_v070
+    desc: 과세매입_공제받지못할_금액/세액
+  "17":
+    price: i_s080
+    vat: i_v080
+    desc: 과세매입_차가감계_금액/세액
+  "100":
+    vat: v_v010
+    desc: 납부환급세액
+  "18":
+    vat: v_v020
+    desc: 경감공제세액_기타경감_세액
+  "19":
+    price: v_s030
+    vat: v_v030
+    desc: 경감공제세액_신용카드매출전표발행공제_금액/세액
+  "20":    
+    vat: v_v040
+    desc: 경감공제세액_합계_세액
+  "20-1":
+    price:
+    vat:
+    desc: 소규모 개인사업자 부가가치세 감면세액
+  "21":
+    vat: pre_notreturn_amt
+    desc: 예정신고미환급세액
+  "22":
+    vat: pre_notice_amt
+    desc: 예정고지세액
+  "23":
+    desc: "사업양수자의 대리납부 기납부세액"
+  "24":
+    vat: v_v050
+    desc: 매입자 납부특례 기납부세액
+  "25":
+    vat: cardcmpy_pay_amt
+    desc: 신용카드업자의 대리납부 기납부세액
+  "26":
+    vat: v_v060
+    desc: 가산세액계
+  "27":
+    vat: real_paytax_amt
+    desc: 차감가감하여 납부할 세액(환급받을 세액)
+  "33":
+    price:
+    vat:
+    desc: 예정누락매출세금계산서금액/세액
+  "34":
+    price:
+    vat:
+    desc: 예정누락매출과세기타금액/세액
+  "35":
+    price:
+    desc: 예정누락매출영세율세금계산서금액
+  "36":
+    price:
+    desc: 예정누락매출영세율기타금액
+  "37":
+    price:
+    vat:
+    desc: 예정누락매출명세합계금액/세액
+  "38":
+    price:
+    vat:
+    desc: 예정누락매입신고세금계산서금액/세액
+  "39":
+    price:
+    vat:
+    desc: 예정누락매입기타공제금액/세액
+  "40":
+    price:
+    vat:
+    desc: 예정누락매입명세합계금액/세액
+  "41":
+    price:
+    vat:
+    desc: 신용카드매출전표등 수령명세서 제출분 > 일반매입
+  "42":
+    price:
+    vat:
+    desc: 신용카드매출전표등 수령명세서 제출분 > 고정자산매입
+  "43":
+    vat:
+    desc: 의제매입세액
+  "44":
+    vat:
+    desc: 제활용폐자원등 매입세액
+  "45":
+    vat:
+    desc: 과세사업전환 매입세액
+  "46":
+    vat: stock_in_vat_amt
+    desc: 재고매입세액
+  "47":
+    vat: debt_pay_vat_amt
+    desc: 변제대손세액
+  "48":
+    vat:
+    desc: 외국인 관광객에 대한 환급세액
+  "49":
+    price:
+    vat:
+    desc: 합계
+  "50":
+    price:
+    vat:
+    desc: 공제받지 못할 매입세액
+  "51":
+    price:
+    vat:
+    desc: 공통매입세액 면세사업등분
+  "52":
+    price:
+    vat:
+    desc: 대손처분받은세액
+  "53":
+    price:
+    vat:
+    desc: 합계
+  "54":
+    vat: elec_ti_deduct_amt
+    desc: 전자신고세액공제
+  "55":
+    vat: elec_ti_deduct_amt
+    desc: 전자세금계산서발행세액공제
+  "56":
+    vat:
+    desc: 택시운송사업자 경감세액
+  "57":
+    vat:
+    desc: 대리납부 세액공제
+  "58":
+    vat:
+    desc: 현금영수증사업자 세액공제
+  "59":
+    vat:
+    desc: 기타
+  "60":
+    vat:
+    desc: 합계
+  "80":
+    price:
+    vat:
+    desc: 면세사업수입금액 > 업태/종목/코드번호/금액
+  "81":
+    price:
+    vat:
+    desc: 면세사업수입금액 > 업태/종목/코드번호/금액
+  "82":
+    price:
+    vat:
+    desc: 면세사업수입금액 > 수입금액제외
+  "83":
+    vat:
+    desc: 면세사업수입금액 > 합계
+  "84":
+    price:
+    desc: 계산서 발급 및 수취 명세 > 계산서 발급금액
+  "85":
+    price:
+    desc: 계산서 발급 및 수취 명세 > 계산서 수취금액
+va_income:
+  "28":
+    name: uptae
+    item: jongmok
+    code: upjong_cd
+    amount: income_amt
+    desc: 과세표준명세 업태/종목/업종코드/금액
+  "29":
+    name: uptae
+    item: jongmok
+    code: upjong_cd
+    amount: income_amt
+    desc: 과세표준명세 업태/종목/업종코드/금액
+  "30":
+    name: uptae
+    item: jongmok
+    code: upjong_cd
+    amount: income_amt
+    desc: 과세표준명세 업태/종목/업종코드/금액
+  "31":
+    amount: 
+    desc: 수입금액 제외
+  "32":
+    amount: 
+    desc: 합계
+va_addtax:
+  "61":
+    price: supply1_amt
+    vat: add1_amt
+    desc: 사업자미등록금액/세액
+  "62":
+    price:
+    vat:
+    desc: 세금계산서 지연발급
+  "63":
+    price:
+    vat:
+    desc: 세금계산서 지연수취
+  "64":
+    price:
+    vat:
+    desc: 세금계산서 미발급
+  "65":
+    price:
+    vat:
+    desc: 전자세금계산서 발급명세 전송 지연전송
+  "66":
+    price:
+    vat:
+    desc: 전자세금계산서 발급명세 전송 미전송
+  "67":
+    price: supply2_amt
+    vat: add2_amt
+    desc: 합계표제출불성실금액/세액
+  "68":
+    price:
+    vat:
+    desc: 세금계산서합계표제출 지연제출 금액/세액
+  "69":
+    price:
+    vat:
+    desc: 신고 불성실 무신고(일반) 금액/세액
+  "70":
+    price:
+    vat:
+    desc: 신고 불성실 무신고(부당) 금액/세액
+  "71":
+    price:
+    vat:
+    desc: 신고 불성실 과소 초과환급신고(일반) 금액/세액
+  "72":
+    price:
+    vat:
+    desc: 신고 불성실 과소 초과환급신고(부당) 금액/세액
+  "73":
+    price: supply4_amt
+    vat: add4_amt
+    desc: 납부불성실금액/세액
+  "74":
+    price: supply5_amt
+    vat: add5_amt
+    desc: 영세율불성실금액/세액
+  "75":
+    price:
+    vat:
+    desc: 현금매출 명세서 불성실 금액/세액
+  "76":
+    price:
+    vat:
+    desc: 부동산임대공급가액며엣서 불성실 금액/세액
+  "77":
+    price:
+    vat:
+    desc: 매입자 납부 특례 거래계좌 미사용 금액/세액
+  "78":
+    price:
+    vat:
+    desc: 매입자 납부 특례 거래계좌 지연입금 금액/세액
+  "79":
+    vat: add_sum_amt
+    desc: 가산세계

--- a/app/models/foodtax/cm_member.rb
+++ b/app/models/foodtax/cm_member.rb
@@ -9,8 +9,15 @@ module Foodtax
     has_many :va_card_slips, foreign_key: :member_cd, primary_key: :member_cd
     has_one :va_card_sum, foreign_key: :member_cd, primary_key: :member_cd
     has_one :va_head, foreign_key: :member_cd, primary_key: :member_cd
-    has_one :va_elec_file_content, foreign_key: :member_cd, primary_key: :member_cd
+    has_one :va_penalty, foreign_key: :member_cd, primary_key: :member_cd
     has_one :va_pseudo_sum, foreign_key: :member_cd, primary_key: :member_cd
+
+    def self.find_or_initialize_by_vat_return(vat_return)
+      self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        member_cd: vat_return.member_cd
+      )
+    end
 
     def self.find_or_initialize_by_declare_user(declare_user)
       cm_member = self.find_or_initialize_by(

--- a/app/models/foodtax/cm_member.rb
+++ b/app/models/foodtax/cm_member.rb
@@ -12,11 +12,52 @@ module Foodtax
     has_one :va_penalty, foreign_key: :member_cd, primary_key: :member_cd
     has_one :va_pseudo_sum, foreign_key: :member_cd, primary_key: :member_cd
 
+    DEFAULT_EMPTY_STRING = %w(tax_type_change_dt biz_dong_cd open_dt closure_dt bank_cd acct_no email biz_addr1 biz_addr2 biz_addr3 biz_addr4 cp_no1 cp_no2 cp_no3 biz_tel_no1 biz_tel_no2 biz_tel_no3)
+    NON_VALIDATABLE_ATTRIBUTES = %w(reg_date updt_date reg_user_id updt_user_id) + DEFAULT_EMPTY_STRING
+    validates_presence_of Foodtax::CmMember.attribute_names.reject{ |attr| NON_VALIDATABLE_ATTRIBUTES.include?(attr) }
+
     def self.find_or_initialize_by_vat_return(vat_return)
       self.find_or_initialize_by(
         cmpy_cd: "00025",
         member_cd: vat_return.member_cd
       )
+    end
+
+    def import_general_form(form)
+      self.tax_type = "1"
+      self.biz_reg_no = form["tax_payer"]&.fetch("registration_number") || ""
+      self.trade_nm = form["tax_payer"]&.fetch("business_name") || ""
+      self.boss_nm = form["tax_payer"]&.fetch("owner_name")
+      self.boss_jumin_no = "#{form["tax_payer"]&.fetch("birthday")}0000001"
+
+      business_address = form["tax_payer"]&.fetch("business_address")
+      self.biz_addr4 = business_address.split[3..]&.join(" ")
+      business_address.split.each_with_index do |address, index|
+        break if index + 1 >= 4
+        self["biz_addr#{index + 1}"] = address
+      end
+
+      h = form.vat_return.business.hometax_business
+      self.corp_yn = (h.taxation_type == "법인사업자") ? "Y" : "N"
+      tax_office = Foodtax::CmTaxOffice.find_by(tax_office_cd: h.official_code)
+      self.alloc_tax_office_cd = h.official_code
+      self.alloc_tax_office_nm = tax_office.tax_office_nm
+
+      self.uptae = form.primary_classification["name"]
+      self.jongmok = form.primary_classification["item"]
+      self.upjong_cd = form.primary_classification["code"]
+      self.email = form["tax_payer"]&.fetch("email")
+
+      self.open_dt = form.vat_return.business.opened_at || ""
+      self.closure_dt = form["tax_payer"]&.fetch("business_closed_at")&.stftime("%Y%m%d") || ""
+
+      cellphone_number = form["tax_payer"]&.fetch("cellphone_number")
+      if cellphone_number
+        self.cp_no1 = cellphone_number[0..2]
+        self.cp_no2 = cellphone_number[3..6]
+        self.cp_no3 = cellphone_number[7..]
+      end
+      save!
     end
 
     def self.find_or_initialize_by_declare_user(declare_user)
@@ -53,10 +94,6 @@ module Foodtax
       cm_member.uptae = division if division.present?
       cm_member.jongmok = business.hometax_classification_name
       cm_member.upjong_cd = business.hometax_classification_code
-      cm_member.bank_cd = ""
-      cm_member.acct_no = ""
-      cm_member.bangi_yn = "X"
-      cm_member.biz_yn = "Y"
       cm_member
     end
 
@@ -69,8 +106,15 @@ module Foodtax
     def default_values
       self.cmpy_cd ||= "00025"
       self.combiz_yn = "N" if combiz_yn.blank?
-      self.use_yn = "Y" if use_yn.blank?
       self.taxaccept_yn = "N" if taxaccept_yn.blank?
+
+      self.bangi_yn = "X" if bangi_yn.blank?
+      self.biz_yn = "Y" if biz_yn.blank?
+      self.use_yn = "Y" if use_yn.blank?
+
+      DEFAULT_EMPTY_STRING.each do |column|
+        self[column] = "" if self[column].blank?
+      end
     end
   end
 end

--- a/app/models/foodtax/va_business_status_form.rb
+++ b/app/models/foodtax/va_business_status_form.rb
@@ -7,11 +7,10 @@ module Foodtax
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
 
-    NON_VALIDATABLE_ATTRIBUTES = %w(REG_DATE UPDT_DATE REG_USER_ID UPDT_USER_ID)
+    NON_VALIDATABLE_ATTRIBUTES = %w(C0100 REG_DATE UPDT_DATE REG_USER_ID UPDT_USER_ID)
     validates_presence_of Foodtax::VaBusinessStatusForm.attribute_names.reject{ |attr| NON_VALIDATABLE_ATTRIBUTES.include?(attr)}
 
     validates :C0010, inclusion: { in: %w(01 02) }
-    validate :C0160, :validate_rental_deposit?
 
     def import_form(form)
       self.C0010 = form.self_rental ? "01" : "02"

--- a/app/models/foodtax/va_business_status_form.rb
+++ b/app/models/foodtax/va_business_status_form.rb
@@ -10,7 +10,8 @@ module Foodtax
     NON_VALIDATABLE_ATTRIBUTES = %w(REG_DATE UPDT_DATE REG_USER_ID UPDT_USER_ID)
     validates_presence_of Foodtax::VaBusinessStatusForm.attribute_names.reject{ |attr| NON_VALIDATABLE_ATTRIBUTES.include?(attr)}
 
-    validate :C0160, :validate_rental_deposit?, on: :create
+    validates :C0010, inclusion: { in: %w(01 02) }
+    validate :C0160, :validate_rental_deposit?
 
     def import_form(form)
       self.C0010 = form.self_rental ? "01" : "02"
@@ -39,8 +40,7 @@ module Foodtax
     end
 
     def validate_rental_deposit?
-      true if self_rental?
-      self.C0160 + self.C0170 > 0
+      errors.add(:C0160, :invalid_rental) if !self_rental? && (self.C0160 + self.C0170 <= 0)
     end
 
     def self_rental?

--- a/app/models/foodtax/va_business_status_form.rb
+++ b/app/models/foodtax/va_business_status_form.rb
@@ -1,0 +1,66 @@
+module Foodtax
+  class VaBusinessStatusForm < Foodtax::ApplicationRecord
+    include FoodtaxHelper
+    self.table_name = "VA_V142_M"
+    self.primary_keys = :member_cd, :cmpy_cd
+    after_initialize :default_values
+
+    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
+
+    NON_VALIDATABLE_ATTRIBUTES = %w(REG_DATE UPDT_DATE REG_USER_ID UPDT_USER_ID)
+    validates_presence_of Foodtax::VaBusinessStatusForm.attribute_names.reject{ |attr| NON_VALIDATABLE_ATTRIBUTES.include?(attr)}
+
+    validate :C0160, :validate_rental_deposit?, on: :create
+
+    def import_form(form)
+      self.C0010 = form.self_rental ? "01" : "02"
+      self.C0020 = form.site_area
+      self.C0030 = form.lower_ground_floors
+      self.C0040 = form.upper_ground_floors
+      self.C0050 = form.building_area
+      self.C0060 = form.total_floor_area
+      self.C0070 = form.rooms_count
+      self.C0080 = form.tables_count
+      self.C0090 = form.seats_count
+      self.C0100 = form.parking_lot ? "Y" : "N"
+      self.C0110 = form.employees_count
+      self.C0120 = form.passenger_cars_count
+      self.C0130 = form.vans_count
+      self.C0140 = "0"
+      self.C0150 = form.first_half? ? "06" : "12"
+      self.C0160 = (form.rental_deposit / 1000.0).to_i
+      self.C0170 = (form.monthly_rental_fee / 1000.0).to_i
+      self.C0180 = (form.electricity_gas_bills / 1000.0).to_i
+      self.C0190 = (form.water_bills / 1000.0).to_i
+      self.C0200 = (form.wage / 1000.0).to_i
+      self.C0210 = (form.etc_expenses / 1000.0).to_i
+      self.C0220 = (form.total_monthly_expenses / 1000.0).to_i
+      save!
+    end
+
+    def validate_rental_deposit?
+      true if self_rental?
+      self.C0160 + self.C0170 > 0
+    end
+
+    def self_rental?
+      self.C0150.eql?("01")
+    end
+
+    private
+
+    def default_values
+      self.cmpy_cd ||= "00025"
+    end
+
+    def default_dates
+      self.REG_DATE ||= Time.now.strftime("%F %T")
+      self.UPDT_DATE ||= Time.now.strftime("%F %T")
+    end
+
+    def default_user_id
+      self.REG_USER_ID = "KCD" if self.REG_USER_ID.blank?
+      self.UPDT_USER_ID = "KCD" if self.UPDT_USER_ID.blank?
+    end
+  end
+end

--- a/app/models/foodtax/va_head.rb
+++ b/app/models/foodtax/va_head.rb
@@ -5,9 +5,24 @@ module Foodtax
     after_initialize :default_values
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
-    has_one :va_elec_file_content, foreign_key: :member_cd, primary_key: :member_cd
 
-    def initialize_with_business(business) # rubocop:disable Metrics/MethodLength
+    def declare_file_plain_text
+      result = Foodtax::VaHead.execute_procedure :sp_va_head_file_gen_cashnote,
+        cmpy_cd: cmpy_cd,
+        member_cd: member_cd,
+        term_cd: term_cd,
+        declare_seq: declare_seq,
+        form_cd: '',
+        login_user_id: 'KCD',
+        return_val: ''
+      result.flatten.first["result"]
+    end
+
+    def declare_file
+      Base64.encode64(declare_file_plain_text.encode("EUC-KR"))
+    end
+
+    def initialize_with_business(business)
       return if business.hometax_business.blank?
       self.biz_addr1 = business.hometax_business.address.split&.first
       self.biz_addr2 = business.hometax_business.address.split&.second

--- a/app/models/foodtax/va_head.rb
+++ b/app/models/foodtax/va_head.rb
@@ -6,15 +6,19 @@ module Foodtax
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
 
+    DEFAULT_EMPTY_STRING = %w(return_bank return_branch return_acct_no biz_addr2 biz_addr3 biz_addr4 biz_tel_no cp_no home_tel_no in_vat_autocal_yn closure_dt closure_reason_type closure_reason_type_nm)
+    NON_VALIDATABLE_ATTRIBUTES = %w(reg_date updt_date reg_user_id updt_user_id) + DEFAULT_EMPTY_STRING
+    validates_presence_of Foodtax::VaHead.attribute_names.reject{ |attr| NON_VALIDATABLE_ATTRIBUTES.include?(attr) }
+
     def declare_file_plain_text
       result = Foodtax::VaHead.execute_procedure :sp_va_head_file_gen_cashnote,
         cmpy_cd: cmpy_cd,
         member_cd: member_cd,
         term_cd: term_cd,
         declare_seq: declare_seq,
-        form_cd: '',
-        login_user_id: 'KCD',
-        return_val: ''
+        form_cd: "",
+        login_user_id: "KCD",
+        return_val: ""
       result.flatten.first["result"]
     end
 
@@ -22,45 +26,97 @@ module Foodtax
       Base64.encode64(declare_file_plain_text.encode("EUC-KR"))
     end
 
-    def initialize_with_business(business)
-      return if business.hometax_business.blank?
-      self.biz_addr1 = business.hometax_business.address.split&.first
-      self.biz_addr2 = business.hometax_business.address.split&.second
-      self.cp_no = business.hometax_business.phone_number || business.owner.phone_number
-      self.tax_type = foodtax_tax_type(business.hometax_business.taxation_type)
-      self.upjong_cd = business.hometax_business.classification_code if business.hometax_business.classification_code
-      self.closure_yn = "Y" if business.closed_at.present?
-      self.closure_dt = business.closed_at.strftime("%Y%m%d") if business.closed_at.present?
-      self.tax_office_cd = business.hometax_business.official_code
-
-      tax_office = Foodtax::CmTaxOffice.find_by(tax_office_cd: business.hometax_business.official_code)
-      self.tax_office_acct_cd = tax_office.acct_cd if tax_office.present?
-      self.self_hometax_id = business.hometax_business.login
-
-      self.term_str_dt = tax_declare_duration(business).first.strftime("%Y%m%d") if term_str_dt.blank?
-      self.term_end_dt = tax_declare_duration(business).last.strftime("%Y%m%d") if term_end_dt.blank?
+    def self.find_or_initialize_by_vat_return(vat_return)
+      self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        member_cd: vat_return.member_cd,
+        term_cd: vat_return.term_cd,
+      )
     end
 
-    def declare_year
-      term_cd[0..3]
-    end
+    def import_general_form(form)
+      mappings = YAML.load_file(Rails.root.join("app/libs/vat/mapping_columns.yml"))
+      mappings["va_head"].each do |k, v|
+        price_field_name = v["price"]
+        vat_field_name = v["vat"]
+        self[price_field_name] = form.value_price(k) if price_field_name.present?
+        self[vat_field_name] = form.value_vat(k) if vat_field_name.present?
+      end
 
-    def declare_term
-      term_cd.last
+      self.term_str_dt = form.period_start_date
+      self.term_end_dt = form.period_end_date      
+
+      self.yieldtax_amt = self.o_v090
+      self.paytax_amt = self.v_v010
+
+      self.return_yn = self.real_paytax_amt < 0 ? "Y" : "N"
+
+      self.tax_cash_sale_amt = 0
+      self.tax_cash_vat_amt = 0
+      self.free_cash_sale_amt = 0
+      self.zero_cash_sale_amt = 0
+
+      set_tax_payer(form)
+
+      save!
     end
 
     private
 
+    def set_tax_payer(form)
+      business_address = form["tax_payer"]&.fetch("business_address")
+      self.biz_addr4 = business_address.split[3..]&.join(" ")
+      business_address.split.each_with_index do |address, index|
+        break if index + 1 >= 4
+        self["biz_addr#{index + 1}"] = address
+      end
+
+      self.return_bank = form["tax_payer"]&.fetch("bank_name")
+      self.return_acct_no = form["tax_payer"]&.fetch("bank_account")
+
+      h = form.vat_return.business.hometax_business
+      tax_office = Foodtax::CmTaxOffice.find_by(tax_office_cd: h.official_code)
+      self.tax_office_cd = h.official_code
+      self.tax_office_acct_cd = tax_office.acct_cd
+      self.self_hometax_id = h.login
+      self.upjong_cd = form.primary_classification["code"]
+
+      self.closure_dt = form["tax_payer"]&.fetch("business_closed_at")&.stftime("%Y%m%d") || ""
+      self.closure_yn = self.closure_dt.blank? ? "N" : "Y"
+      self.closure_reason_type = ""
+      self.closure_reason_type_nm = ""
+
+      self.biz_tel_no = form["tax_payer"]&.fetch("business_phone_number") || ""
+      self.cp_no = form["tax_payer"]&.fetch("cellphone_number") || ""
+      self.home_tel_no = form["tax_payer"]&.fetch("phone_number") || ""
+    end
+
     def default_values
       self.cmpy_cd ||= "00025"
-      self.term_cd ||= "#{tax_declare_year}#{tax_declare_term}"
       self.declare_seq ||= "1"
+      self.declare_type = "1"
 
-      self.declare_due_dt = Date.today.strftime("%Y%m%d") if declare_due_dt.blank?
+      self.easyvat_exempt_yn = "N"
+      self.tax_type = "1"
+      self.self_declare_yn = "Y"
 
-      self.close_yn = "Y" if close_yn.blank?
-      self.file_make_yn = "N" if file_make_yn.blank?
-      self.self_declare_yn = "Y" if self_declare_yn.blank?
+      self.declare_due_dt = "20200727"
+      self.declare_dt = Date.current.strftime("%Y%m%d") if declare_dt.blank?
+
+      DEFAULT_EMPTY_STRING.each do |column|
+        self[column] = "" if self[column].blank?
+      end
+
+      self.close_yn = "Y"
+      self.close_dt = Date.current.strftime("%Y%m%d")
+      self.close_user_id = "KCD"
+
+      self.file_make_yn = "N"
+      self.file_make_dt = Date.current.strftime("%Y%m%d")
+      self.file_make_cnt = 0
+      self.file_make_user_id = "KCD"
+
+      self.cta_cmpy_cd = "9000"
     end
   end
 end

--- a/app/models/foodtax/va_income.rb
+++ b/app/models/foodtax/va_income.rb
@@ -1,14 +1,13 @@
 module Foodtax
-  class VaPenalty < Foodtax::ApplicationRecord
+  class VaIncome < Foodtax::ApplicationRecord
     include FoodtaxHelper
-    self.table_name = "va_addtax"
     self.primary_keys = :member_cd, :cmpy_cd, :term_cd, :declare_seq
     after_initialize :default_dates, :default_user_id, :default_values
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
 
     NON_VALIDATABLE_ATTRIBUTES = %w(REG_DATE UPDT_DATE REG_USER_ID UPDT_USER_ID)
-    validates_presence_of Foodtax::VaPenalty.attribute_names.reject{ |attr| NON_VALIDATABLE_ATTRIBUTES.include?(attr)}
+    validates_presence_of Foodtax::VaIncome.attribute_names.reject{ |attr| NON_VALIDATABLE_ATTRIBUTES.include?(attr)}
 
     def self.find_or_initialize_by_vat_form(form)
       self.find_or_initialize_by(
@@ -18,37 +17,32 @@ module Foodtax
       )
     end
 
-    def import_general_form(form)
-      self.supply1_amt = form.value_price("61")
-      self.add1_amt = form.value_vat("61")
-
-      self.supply2_amt = form.value_price("67")
-      self.add2_amt = form.value_vat("67")
-
-      self.supply3_amt = 0
-      self.add3_amt = 0
-
-      %w(69 70 71 72).each do |key|
-        self.supply3_amt += form.value_price("key")
-        self.add3_amt += form.value_vat("key")
+    def self.import_form(form)
+      va_income = self.find_or_initialize_by_vat_form(form)
+      index = 1
+      %w(28 29 30).each do |k|       
+        values = form.converted_hash_by_order_number[k]
+        next if values.blank? || values["amount"].blank?
+        va_income.seq_no = index
+        va_income.uptae = values["name"]
+        va_income.jongmok = values["item"]
+        va_income.upjong_cd = values["code"]
+        va_income.income_amt = values["amount"]
+        va_income.easyvat_rate_type = ""
+        va_income.easyvat_rate = ""
+        va_income.save!
+        index = index + 1
       end
-
-      self.supply4_amt = form.value_price("73")
-      self.add4_amt = form.value_vat("73")
-
-      self.supply5_amt = form.value_price("74")
-      self.add5_amt = form.value_vat("74")
-      
-      self.add_sum_amt = form.value_vat("79")
-      save!
     end
 
     private
 
     def default_values
       self.cmpy_cd ||= "00025"
-      self.term_cd ||= "#{tax_declare_year}#{tax_declare_term}"
       self.declare_seq ||= "1"
+      self.tax_type = "1"
+      self.declare_seq = "1"
+      self.tax_type = "1"
     end
 
     def default_dates

--- a/app/models/foodtax/va_penalty.rb
+++ b/app/models/foodtax/va_penalty.rb
@@ -7,6 +7,9 @@ module Foodtax
 
     belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
 
+    NON_VALIDATABLE_ATTRIBUTES = %w(REG_DATE UPDT_DATE REG_USER_ID UPDT_USER_ID)
+    validates_presence_of Foodtax::VaPenalty.attribute_names.reject{ |attr| NON_VALIDATABLE_ATTRIBUTES.include?(attr)}
+
     def self.find_or_initialize_by_vat_form(form)
       self.find_or_initialize_by(
         cmpy_cd: "00025",

--- a/app/models/foodtax/va_penalty.rb
+++ b/app/models/foodtax/va_penalty.rb
@@ -1,0 +1,68 @@
+module Foodtax
+  class VaPenalty < Foodtax::ApplicationRecord
+    include FoodtaxHelper
+    self.table_name = "va_addtax"
+    self.primary_keys = :member_cd, :cmpy_cd, :term_cd, :declare_seq
+    after_initialize :default_dates, :default_user_id, :default_values
+
+    belongs_to :cm_member, foreign_key: :member_cd, primary_key: :member_cd
+
+    def self.find_or_initialize_by_vat_form(form)
+      self.find_or_initialize_by(
+        cmpy_cd: "00025",
+        member_cd: form.vat_return.member_cd,
+        term_cd: form.vat_return.term_cd,
+      )
+    end
+
+    def import_form(form)
+      supply1 = form.converted_hash_by_order_number["61"]
+      supply2 = form.converted_hash_by_order_number["67"]
+      supply4 = form.converted_hash_by_order_number["73"]
+      supply5 = form.converted_hash_by_order_number["74"]
+      total_sum = form.converted_hash_by_order_number["79"]
+
+      self.supply1_amt = supply1.dig("value", "amount")
+      self.add1_amt = supply1.dig("value", "vat")
+
+      self.supply2_amt = supply2.dig("value", "amount")
+      self.add2_amt = supply2.dig("value", "vat")
+
+      self.supply3_amt = 0
+      self.add3_amt = 0
+
+      %w(69 70 71 72).each do |key|        
+        penalty = form.converted_hash_by_order_number[key]
+        self.supply3_amt += penalty.dig("value", "amount")
+        self.add3_amt += penalty.dig("value", "amount")
+      end
+
+      self.supply4_amt = supply4.dig("value", "amount")
+      self.add4_amt = supply4.dig("value", "vat")
+
+      self.supply5_amt = supply5.dig("value", "amount")
+      self.add5_amt = supply5.dig("value", "vat")
+      
+      self.add_sum_amt = total_sum.dig("value", "vat")
+      save!
+    end
+
+    private
+
+    def default_values
+      self.cmpy_cd ||= "00025"
+      self.term_cd ||= "#{tax_declare_year}#{tax_declare_term}"
+      self.declare_seq ||= "1"
+    end
+
+    def default_dates
+      self.REG_DATE ||= Time.now.strftime("%F %T")
+      self.UPDT_DATE ||= Time.now.strftime("%F %T")
+    end
+
+    def default_user_id
+      self.REG_USER_ID = "KCD" if self.REG_USER_ID.blank?
+      self.UPDT_USER_ID = "KCD" if self.UPDT_USER_ID.blank?
+    end
+  end
+end

--- a/app/models/snowdon/business_status_form.rb
+++ b/app/models/snowdon/business_status_form.rb
@@ -1,0 +1,8 @@
+class Snowdon::BusinessStatusForm < Snowdon::ApplicationRecord
+  enum declare_period: { first_half: "상반기", second_half: "하반기" }
+  belongs_to :business
+
+  def first_half?
+    declare_period.eql?("first_half")
+  end
+end

--- a/app/models/snowdon/general_vat_return_form.rb
+++ b/app/models/snowdon/general_vat_return_form.rb
@@ -1,0 +1,13 @@
+class Snowdon::GeneralVatReturnForm < Snowdon::ApplicationRecord
+  belongs_to :vat_return
+
+  def converted_hash_by_order_number
+    @converted_hash_by_order_number ||= begin
+      converted_hash = {}
+      (accessed_fields - %w{id tax_payer created_at updated_at vat_return_id status}).each do |field|
+        converted_hash.merge!(self[field].map{ |s| {s["order_number"].to_s => s }  }.inject(:merge))
+      end
+      converted_hash
+    end
+  end
+end

--- a/app/models/snowdon/general_vat_return_form.rb
+++ b/app/models/snowdon/general_vat_return_form.rb
@@ -10,4 +10,24 @@ class Snowdon::GeneralVatReturnForm < Snowdon::ApplicationRecord
       converted_hash
     end
   end
+
+  def value_price(order_number)
+    converted_hash_by_order_number[order_number]&.dig("value", "amount") || 0
+  end
+
+  def value_vat(order_number)
+    converted_hash_by_order_number[order_number]&.dig("value", "vat") || 0
+  end
+
+  def period_start_date
+    vat_return.period.eql?(1) ? "#{vat_return.year}0101"  : "#{vat_return.year}0701"
+  end
+
+  def period_end_date
+    vat_return.period.eql?(1) ? "#{vat_return.year}0630"  : "#{vat_return.year}1231"
+  end
+
+  def primary_classification
+    converted_hash_by_order_number["28"]
+  end
 end

--- a/app/models/snowdon/vat_return.rb
+++ b/app/models/snowdon/vat_return.rb
@@ -1,0 +1,38 @@
+class Snowdon::VatReturn < Snowdon::ApplicationRecord
+  enum status: {
+    started: 0,
+    form_generated: 1,
+    file_requested: 2,
+    file_created: 3,
+    finished: 4,
+  }
+
+  belongs_to :business
+
+  has_one :pre_form, class_name: "GeneralVatReturnPreForm"
+  has_one :form, class_name: "GeneralVatReturnForm"
+  has_many :extra_sales_recaps, class_name: "VatReturnExtraSalesRecap"
+  has_many :personal_card_purchases, class_name: "VatReturnPersonalCardPurchase"
+  has_many :paper_invoices, class_name: "VatReturnPaperInvoice"
+  has_many :deductible_purchases, class_name: "VatReturnDeductiblePurchase"
+  has_many :deemed_purchases, class_name: "VatReturnDeemedPurchase"
+
+  validates :year, presence: true
+  validates :period, uniqueness: { scope: %i(business year) }, inclusion: { in: [1, 2] }
+  validates :status, presence: true
+  validates :started_at, presence: true
+  validates :form_generated_at, presence: true, if: :form_generated?
+  validates :file_requested_at, presence: true, if: :file_requested?
+  validates :electronic_file, presence: true, if: :file_created?
+  validates :file_created_at, presence: true, if: :file_created?
+  validates :finished_at, presence: true, if: :finished?
+  validates :return_response, presence: true, if: :finished?
+
+  def member_cd
+    "M#{business.id}"
+  end
+
+  def term_cd
+   "#{year}#{period}"
+  end
+end

--- a/app/services/create_vat_elec_file.rb
+++ b/app/services/create_vat_elec_file.rb
@@ -1,0 +1,22 @@
+class CreateVatElecFile < Service::Base
+  param :vat_return_id
+  
+  def run
+    vat_return = Snowdon::VatReturn.find(vat_return_id)
+    ActiveRecord::Base.transaction do
+      Foodtax::CmCharge.create!(member_cd: vat_return.member_cd)
+
+      cm_member = Foodtax::CmMember.new(member_cd: vat_return.member_cd)
+      cm_member.initialize_with_business(vat_return.business)
+      cm_member.save!
+
+      va_head = Foodtax::VaHead.new(
+        member_cd: vat_return.business.member_cd,
+        declare_type: "1",
+        declare_due_dt: tax_declare_due_date,
+        declare_dt: Date.current.strftime("%Y%m%d")
+      )
+      va_head.declare_file
+    end
+  end
+end

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -9,6 +9,10 @@ ko:
         residence_number: 주민등록번호
     errors:
       models:
+        foodtax/va_business_status_form:
+          attributes:
+            C0160:
+              invalid_rental: 타가인 경우 보증금과 월세가 0보다 커야 합니다.
         deductible_person:
           attributes:
             residence_number:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,4 +41,5 @@ Rails.application.routes.draw do
   get "hometax_business_incomes/incomes", to: "hometax_business_incomes#incomes"
   post "hometax/scraped_callback", to: "hometax#scraped_callback"
   get "estimated_income_taxes", to: "estimated_income_taxes#index"
+  resources :vat_returns, only: [:create]
 end


### PR DESCRIPTION
AT-227 부가세 기본 HEADER
AT-229 부가세 일반과세자 신고서 레코드
AT-230 부가세 수입금액등 (과세표준명세, 면세수입금액) 레코드
AT-232 부가세 가산세 레코드
AT-233 부가세 사업장현황명세서 레코드

부가세 일반과세자의 기본 푸드택스 모델을 생성한다.
- 부가세 HEADER 레코드
- 일반과세자 신고서 레코드
- 사업장 현황명세서 레코드
- 가산세 레코드 레코드
- 과세표준 레코드

또한 기본 푸드택스 멤버를 추가하고 전자신고 파일을 생성하는 서비스를 생성한다.


